### PR TITLE
fix: Use non-blocking poll after production; allow flush for testing

### DIFF
--- a/edx_event_bus_kafka/management/commands/produce_event.py
+++ b/edx_event_bus_kafka/management/commands/produce_event.py
@@ -59,6 +59,7 @@ class Command(BaseCommand):
                 topic=options['topic'][0],
                 event_key_field=options['key_field'][0],
                 event_data=json.loads(options['data'][0]),
+                sync=True,  # otherwise command may exit before delivery is complete
             )
         except Exception:  # pylint: disable=broad-except
             logger.exception("Error producing Kafka event")


### PR DESCRIPTION
I believe a nullary call to poll uses a default timeout of -1 (wait
indefinitely), but we really just want to make sure that pending callbacks
are triggered for the acks that have been buffered in the background, from
previous events. poll(0) will not block if the buffer is empty.

For testing we need to call flush(-1), so add sync=True as an option.

Documentation for `rd_kafka_poll`:
https://github.com/edenhill/librdkafka/blob/4faeb8132521da70b6bcde14423a14eb7ed5c55e/src/rdkafka.h#L3079

This addresses part of https://github.com/openedx/event-bus-kafka/issues/10