### PR TITLE
feat: Specify signals to consumer management command.

### DIFF
--- a/edx_event_bus_kafka/__init__.py
+++ b/edx_event_bus_kafka/__init__.py
@@ -2,4 +2,4 @@
 Kafka implementation for Open edX event bus.
 """
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'


### PR DESCRIPTION
**Description:** This adds the ability to specify any signal to emit
from messages that are pulled from the message queue.

If the message's signal type doesn't match the signal
type specified to the command, that message is dropped.

This also refactors some of the code to help track state.

**JIRA:** [Link to JIRA ticket](https://github.com/openedx/event-bus-kafka/issues/4)

**Testing instructions:**

1. Run `make test`

**Reviewers:**
- [ ] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
