### PR TITLE
feat: Deduplicate config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,15 @@ Unreleased
 
 *
 
+[0.3.0] - 2022-08-10
+~~~~~~~~~~~~~~~~~~~~
+
+Updated
+_______
+
+* Moved configuration onto separate file.
+* Updated configuration settings to have EVENT_BUS_KAFKA prefix.
+
 [0.2.0] - 2022-08-09
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/edx_event_bus_kafka/__init__.py
+++ b/edx_event_bus_kafka/__init__.py
@@ -2,4 +2,4 @@
 Kafka implementation for Open edX event bus.
 """
 
-__version__ = '0.2.0'
+__version__ = '0.3.0'

--- a/edx_event_bus_kafka/config.py
+++ b/edx_event_bus_kafka/config.py
@@ -1,0 +1,54 @@
+"""
+Configuration loading and validation.
+"""
+
+import warnings
+from typing import Optional
+
+from confluent_kafka.schema_registry import SchemaRegistryClient
+from django.conf import settings
+
+
+def create_schema_registry_client() -> Optional[SchemaRegistryClient]:
+    """
+    Create a schema registry client from common settings.
+    """
+    url = getattr(settings, 'EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL', None)
+    if url is None:
+        warnings.warn("Cannot configure event-bus-kafka: Missing setting EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL")
+        return None
+
+    key = getattr(settings, 'EVENT_BUS_KAFKA_SCHEMA_REGISTRY_API_KEY', '')
+    secret = getattr(settings, 'EVENT_BUS_KAFKA_SCHEMA_REGISTRY_API_SECRET', '')
+
+    return SchemaRegistryClient({
+        'url': url,
+        'basic.auth.user.info': f"{key}:{secret}",
+    })
+
+
+def load_common_settings() -> Optional[dict]:
+    """
+    Load common settings, a base for either producer or consumer configuration.
+    """
+    bootstrap_servers = getattr(settings, 'EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS', None)
+    if bootstrap_servers is None:
+        warnings.warn("Cannot configure event-bus-kafka: Missing setting EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS")
+        return None
+
+    base_settings = {
+        'bootstrap.servers': bootstrap_servers,
+    }
+
+    key = getattr(base_settings, 'EVENT_BUS_KAFKA_API_KEY', None)
+    secret = getattr(base_settings, 'EVENT_BUS_KAFKA_API_SECRET', None)
+
+    if key and secret:
+        base_settings.update({
+            'sasl.mechanism': 'PLAIN',
+            'security.protocol': 'SASL_SSL',
+            'sasl.username': key,
+            'sasl.password': secret,
+        })
+
+    return base_settings

--- a/edx_event_bus_kafka/publishing/test_event_producer.py
+++ b/edx_event_bus_kafka/publishing/test_event_producer.py
@@ -74,10 +74,10 @@ class TestEventProducer(TestCase):
         """Creation succeeds when all settings are present."""
         signal = openedx_events.learning.signals.SESSION_LOGIN_COMPLETED
         with override_settings(
-                SCHEMA_REGISTRY_URL='http://localhost:12345',
-                SCHEMA_REGISTRY_API_KEY='some_key',
-                SCHEMA_REGISTRY_API_SECRET='some_secret',
-                KAFKA_BOOTSTRAP_SERVERS='http://localhost:54321',
+                EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL='http://localhost:12345',
+                EVENT_BUS_KAFKA_SCHEMA_REGISTRY_API_KEY='some_key',
+                EVENT_BUS_KAFKA_SCHEMA_REGISTRY_API_SECRET='some_secret',
+                EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='http://localhost:54321',
                 # include these just to maximize code coverage
                 KAFKA_API_KEY='some_other_key',
                 KAFKA_API_SECRET='some_other_secret',


### PR DESCRIPTION
Deduplicating configuration into config file
The config file is mostly the same as the common-config given, null checks are added in to the get_producer function in order to accomodate these functions on a separate file. 

@timmc-edx when you wrote the override_settings in the test file did you intend for the name of the settings (SCHEMA_REGISTRY_URL for example) to not have EVENT_BUS_KAFKA before it? I couldn't make the tests run as intended without the EVENT_BUS_KAFKA in front of it.