### PR TITLE
refactor: Consumer uses the same config loading as producer.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,14 @@ Unreleased
 
 *
 
+[0.3.1] - 2022-08-11
+~~~~~~~~~~~~~~~~~~~~
+
+Updated
+_______
+
+* Refactored consumer to use common configuration.
+
 [0.3.0] - 2022-08-10
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/edx_event_bus_kafka/__init__.py
+++ b/edx_event_bus_kafka/__init__.py
@@ -2,4 +2,4 @@
 Kafka implementation for Open edX event bus.
 """
 
-__version__ = '0.3.0'
+__version__ = '0.3.1'

--- a/edx_event_bus_kafka/consumer/tests/test_event_consumer.py
+++ b/edx_event_bus_kafka/consumer/tests/test_event_consumer.py
@@ -49,10 +49,10 @@ class FakeMessage:
 
 
 @override_settings(
-    SCHEMA_REGISTRY_URL='https://test-url',
-    KAFKA_BOOTSTRAP_SERVERS='bootstrap-servers',
-    KAFKA_API_KEY='test-key',
-    KAFKA_API_SECRET='test-secret',
+    EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL='https://test-url',
+    EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='bootstrap-servers',
+    EVENT_BUS_KAFKA_API_KEY='test-key',
+    EVENT_BUS_KAFKA_API_SECRET='test-secret',
 )
 class TestEmitSignals(TestCase):
     """


### PR DESCRIPTION
We also refactor the consumer to use a common config.

https://github.com/openedx/event-bus-kafka/issues/15

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
