### PR TITLE
feat!: Ensure all settings have consistent `EVENT_BUS_KAFKA_` prefix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,18 @@ Unreleased
 
 *
 
+[0.4.0] - 2022-08-12
+~~~~~~~~~~~~~~~~~~~~
+
+Changed
+_______
+
+* Rename settings to have consistent prefix.
+
+  * ``KAFKA_CONSUMERS_ENABLED`` becomes ``EVENT_BUS_KAFKA_CONSUMERS_ENABLED``
+  * ``CONSUMER_POLL_TIMEOUT`` becomes ``EVENT_BUS_KAFKA_CONSUMER_POLL_TIMEOUT``
+  * Updates to documentation and tests for various settings previously renamed
+
 [0.3.1] - 2022-08-11
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ The documentation/ADRs may also be moved to more appropriate places as the proce
 
 There are a hefty number of "# TODO (EventBus)" annotations left in to help guide further development.
 While still under development, this app will be subject to frequent and rapid changes.
-Outside of testing this app, it is best to leave the KAFKA_CONSUMERS_ENABLED setting off.
+Outside of testing this app, it is best to leave the ``EVENT_BUS_KAFKA_CONSUMERS_ENABLED`` setting off.
 
 The repository works together with the openedx/openedx-events repository to make the fully functional event bus.
 

--- a/docs/how_tos/manual_testing.rst
+++ b/docs/how_tos/manual_testing.rst
@@ -11,9 +11,9 @@ The producer can be tested manually against a Kafka running in devstack.
    - Add ``'edx_event_bus_kafka'`` to the ``INSTALLED_APPS`` list
    - Add the following::
 
-       KAFKA_CONSUMERS_ENABLED = True
-       KAFKA_BOOTSTRAP_SERVERS = "edx.devstack.kafka:29092"
-       SCHEMA_REGISTRY_URL = "http://edx.devstack.schema-registry:8081"
+       EVENT_BUS_KAFKA_CONSUMERS_ENABLED = True
+       EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS = "edx.devstack.kafka:29092"
+       EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL = "http://edx.devstack.schema-registry:8081"
 
 #. In devstack, run ``make devpi-up studio-up-without-deps-shell`` to bring up Studio with a shell.
 #. In the Studio shell, run ``pip install -e /edx/src/event-bus-kafka``

--- a/edx_event_bus_kafka/__init__.py
+++ b/edx_event_bus_kafka/__init__.py
@@ -2,4 +2,4 @@
 Kafka implementation for Open edX event bus.
 """
 
-__version__ = '0.3.1'
+__version__ = '0.4.0'

--- a/edx_event_bus_kafka/consumer/README.rst
+++ b/edx_event_bus_kafka/consumer/README.rst
@@ -7,4 +7,4 @@ Purpose
 
 This part of the library implements event bus consumer patterns using the Confluent Kafka API.
 
-During development, this app will be subject to frequent and rapid changes. Outside of testing this app, it is best to leave the KAFKA_CONSUMERS_ENABLED setting off.
+During development, this app will be subject to frequent and rapid changes. Outside of testing this app, it is best to leave the ``EVENT_BUS_KAFKA_CONSUMERS_ENABLED`` setting off.

--- a/edx_event_bus_kafka/consumer/event_consumer.py
+++ b/edx_event_bus_kafka/consumer/event_consumer.py
@@ -19,16 +19,16 @@ from edx_event_bus_kafka.config import create_schema_registry_client, load_commo
 
 logger = logging.getLogger(__name__)
 
-# .. toggle_name: KAFKA_CONSUMERS_ENABLED
+# .. toggle_name: EVENT_BUS_KAFKA_CONSUMERS_ENABLED
 # .. toggle_implementation: SettingToggle
 # .. toggle_default: False
 # .. toggle_description: Enables the ability to listen and process events from the Kafka event bus
 # .. toggle_use_cases: opt_in
 # .. toggle_creation_date: 2022-01-31
 # .. toggle_tickets: https://openedx.atlassian.net/browse/ARCHBOM-1992
-KAFKA_CONSUMERS_ENABLED = SettingToggle('KAFKA_CONSUMERS_ENABLED', default=False)
+KAFKA_CONSUMERS_ENABLED = SettingToggle('EVENT_BUS_KAFKA_CONSUMERS_ENABLED', default=False)
 
-CONSUMER_POLL_TIMEOUT = getattr(settings, 'CONSUMER_POLL_TIMEOUT', 1.0)
+CONSUMER_POLL_TIMEOUT = getattr(settings, 'EVENT_BUS_KAFKA_CONSUMER_POLL_TIMEOUT', 1.0)
 
 # CloudEvent standard name for the event type header, see
 # https://github.com/cloudevents/spec/blob/v1.0.1/kafka-protocol-binding.md#325-example
@@ -156,7 +156,8 @@ class KafkaEventConsumer:
 
 class ConsumeEventsCommand(BaseCommand):
     """
-    Listen for events from the event bus and log them. Only run on servers where KAFKA_CONSUMERS_ENABLED is true
+    Listen for events from the event bus and log them. Only run on servers where
+    ``EVENT_BUS_KAFKA_CONSUMERS_ENABLED`` is true.
     """
     help = """
     This starts a Kafka event consumer that listens to the specified topic and logs all messages it receives. Topic

--- a/edx_event_bus_kafka/consumer/tests/test_event_consumer.py
+++ b/edx_event_bus_kafka/consumer/tests/test_event_consumer.py
@@ -126,7 +126,7 @@ class TestCommand(TestCase):
     Tests for the consume_events management command
     """
 
-    @override_settings(KAFKA_CONSUMERS_ENABLED=False)
+    @override_settings(EVENT_BUS_KAFKA_CONSUMERS_ENABLED=False)
     @patch('edx_event_bus_kafka.consumer.event_consumer.KafkaEventConsumer._create_consumer')
     def test_kafka_consumers_disabled(self, mock_create_consumer):
         call_command(Command(), topic='test', group_id='test', signal='')

--- a/edx_event_bus_kafka/publishing/test_event_producer.py
+++ b/edx_event_bus_kafka/publishing/test_event_producer.py
@@ -79,8 +79,8 @@ class TestEventProducer(TestCase):
                 EVENT_BUS_KAFKA_SCHEMA_REGISTRY_API_SECRET='some_secret',
                 EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='http://localhost:54321',
                 # include these just to maximize code coverage
-                KAFKA_API_KEY='some_other_key',
-                KAFKA_API_SECRET='some_other_secret',
+                EVENT_BUS_KAFKA_API_KEY='some_other_key',
+                EVENT_BUS_KAFKA_API_SECRET='some_other_secret',
         ):
             assert isinstance(ep.get_producer_for_signal(signal, 'user.id'), SerializingProducer)
 


### PR DESCRIPTION
This changes `KAFKA_CONSUMERS_ENABLED` and `CONSUMER_POLL_TIMEOUT` and
updates documentation and tests for other settings.

**Merge checklist:**
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed