### PR TITLE
feat: Never evict producers from cache

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,14 @@ Unreleased
 
 *
 
+[0.4.3] - 2022-08-24
+********************
+
+Fixed
+=====
+
+* Never evict producers from cache. There wasn't a real risk of this, but now we can rely on them being long-lived. Addresses remainder of `<https://github.com/openedx/event-bus-kafka/issues/16>`__.
+
 [0.4.2] - 2022-08-24
 ********************
 

--- a/edx_event_bus_kafka/__init__.py
+++ b/edx_event_bus_kafka/__init__.py
@@ -2,4 +2,4 @@
 Kafka implementation for Open edX event bus.
 """
 
-__version__ = '0.4.2'
+__version__ = '0.4.3'

--- a/edx_event_bus_kafka/publishing/test_event_producer.py
+++ b/edx_event_bus_kafka/publishing/test_event_producer.py
@@ -24,11 +24,6 @@ except ImportError:  # pragma: no cover
 class TestEventProducer(TestCase):
     """Test producer."""
 
-    def setUp(self):
-        super().setUp()
-        ep.get_producer_for_signal.cache_clear()
-        ep.get_serializer.cache_clear()
-
     def test_extract_event_key(self):
         event_data = {
             'user': UserData(


### PR DESCRIPTION
This should close out https://github.com/openedx/event-bus-kafka/issues/16
by just embracing the use of multiple producers.

Also:

- Improve cache-clearing during tests by connecting to the setting_changed
  signal -- this allows knowledge of what's cached to be local to the
  module where the caching happens, rather than relying on each test module
  to know about all of the modules it depends on indirectly.
- Remove outdated comment about caching, and clarify other caching
  comments.

**Merge checklist:**
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed