### PR TITLE
docs: Update PR template to something people might actually use

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,39 +1,8 @@
-**Description:** Describe in a couple of sentences what this PR adds
-
-**JIRA:** Link to JIRA ticket
-
-**Dependencies:** dependencies on other outstanding PRs, issues, etc. 
-
-**Merge deadline:** List merge deadline (if any)
-
-**Installation instructions:** List any non-trivial installation 
-instructions.
-
-**Testing instructions:**
-
-1. Open page A
-2. Do thing B
-3. Expect C to happen
-4. If D happened instead - check failed.
-
-**Reviewers:**
-- [ ] tag reviewer 
-- [ ] tag reviewer 
 
 **Merge checklist:**
-- [ ] All reviewers approved
-- [ ] CI build is green
+Check off if complete *or* not applicable:
 - [ ] Version bumped
 - [ ] Changelog record added
 - [ ] Documentation updated (not only docstrings)
 - [ ] Commits are squashed
-
-**Post merge:**
-- [ ] Create a tag
-- [ ] Check new version is pushed to PyPI after tag-triggered build is 
-      finished.
-- [ ] Delete working branch (if not needed anymore)
-
-**Author concerns:** List any concerns about this PR - inelegant 
-solutions, hacks, quick-and-dirty implementations, concerns about 
-migrations, etc.
+- [ ] Noted any: Concerns, dependencies, deadlines, tickets, testing instructions


### PR DESCRIPTION
I notice that people largely ignore PR templates, *especially* big ones.
I think that shrinking this down to just the essentials will increase the
likelihood that people use it.

In particular, I want to remove things like "All reviewers approved" and
"CI build is green" that are generally already enforced by repo policies,
"Delete working branch" (there's a setting for that if we want it!), and
release instructions (should be in a central document linked from the
README).


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
- [x] Noted any: Concerns, dependencies, deadlines, tickets, testing instructions
