### PR TITLE
test: Leave confluent_kafka imports undefined in tests

### DIFF
--- a/docs/decisions/0005-optional-import-of-confluent-kafka.rst
+++ b/docs/decisions/0005-optional-import-of-confluent-kafka.rst
@@ -29,12 +29,12 @@ For example::
     try:
         import confluent_kafka
         from confluent_kafka import DeserializingConsumer
-    except ImportError:
+    except ImportError:  # pragma: no cover
         confluent_kafka = None
 
 Then, later on, before any usage of ``DeserializingConsumer``::
 
-    if not confluent_kafka:
+    if not confluent_kafka:  # pragma: no cover
         warn("Confluent_kafka not installed")
         return None
     ...do things with DeserializingConsumer
@@ -44,7 +44,7 @@ For test modules, we can do something simpler; we'll always run tests with ``con
     # See https://github.com/openedx/event-bus-kafka/blob/main/docs/decisions/0005-optional-import-of-confluent-kafka.rst
     try:
         from confluent_kafka import DeserializingConsumer
-    except ImportError:
+    except ImportError:  # pragma: no cover
         pass
 
 Consequences

--- a/docs/decisions/0005-optional-import-of-confluent-kafka.rst
+++ b/docs/decisions/0005-optional-import-of-confluent-kafka.rst
@@ -1,4 +1,4 @@
-4. Optional import of confluent-kafka
+5. Optional import of confluent-kafka
 #####################################
 
 Status
@@ -10,7 +10,7 @@ Context
 *******
 
 * `confluent-kafka`_ is a library written and maintained by Confluent, our managed instance provider (see :doc:`0004-kafka-managed-hosting`). The library abstracts out the work for sending and receiving events to and from the Kafka cluster and converting them into message objects.
-* confluent-kafka in turn is a wrapper around a C library called `librdkafka`_ (distributed as `librdkafka_dev`)
+* confluent-kafka in turn is a wrapper around a C library called `librdkafka`_ (distributed as ``librdkafka_dev``)
 * librdkafka-dev does not currently have a compiled binary available for Linux/aarch64
 
 As a result of the points above, if a package includes a dependency on confluent-kafka, installation will fail in Linux/aarch64 environments. This is a particular problem for developers who are using Tutor on an M1 Mac. Tutor is the standard distribution for Open edX developers and maintainers, so this is a significant issue for a large part of the community.
@@ -21,22 +21,31 @@ As a result of the points above, if a package includes a dependency on confluent
 Decision
 ********
 
-Instead of requiring confluent-kafka directly in base.in, we will wrap all imports of `confluent_kafka`in a `try...catch` block. If the import fails, the library will log an informative message and any calls will fail gracefully.
+Instead of requiring confluent-kafka directly in base.in, we will wrap all imports of ``confluent_kafka`` in a ``try...catch`` block. If the import fails, the library will log an informative message and any calls will fail gracefully.
 
 For example::
 
+    # See https://github.com/openedx/event-bus-kafka/blob/main/docs/decisions/0005-optional-import-of-confluent-kafka.rst
     try:
         import confluent_kafka
         from confluent_kafka import DeserializingConsumer
     except ImportError:
         confluent_kafka = None
 
-Then, later on, before any usage of `DeserializingConsumer`::
+Then, later on, before any usage of ``DeserializingConsumer``::
 
     if not confluent_kafka:
         warn("Confluent_kafka not installed")
         return None
     ...do things with DeserializingConsumer
+
+For test modules, we can do something simpler; we'll always run tests with ``confluent_kafka`` installed (it's in ``test.in``) and so do not need to set and check a flag. However, the import should still be allowed to fail silently on the off-chance that a test module is somehow loaded by tooling in a relying IDA. So, test modules can do something like this::
+
+    # See https://github.com/openedx/event-bus-kafka/blob/main/docs/decisions/0005-optional-import-of-confluent-kafka.rst
+    try:
+        from confluent_kafka import DeserializingConsumer
+    except ImportError:
+        pass
 
 Consequences
 ************
@@ -49,12 +58,12 @@ that use this library.
 Rejected Alternatives
 *********************
 
-* Make the entire `edx-event-bus-kafka` library an optional dependency in the services that use it (eg edx-platform, course-discovery)
+* Make the entire ``edx-event-bus-kafka`` library an optional dependency in the services that use it (eg edx-platform, course-discovery)
 
-This would require developers to install `edx-event-bus-kafka` separately when setting up their environment. This means it would not be able to be updated with `make upgrade` in the same way we manage versions of all of our other packages. Moreover, this would require separate commits to update the version of the package and update the code that uses it, meaning we would have to use an expand-contract release model for every breaking change. This goes against best practices, being highly error-prone.
+This would require developers to install ``edx-event-bus-kafka`` separately when setting up their environment. This means it would not be able to be updated with ``make upgrade`` in the same way we manage versions of all of our other packages. Moreover, this would require separate commits to update the version of the package and update the code that uses it, meaning we would have to use an expand-contract release model for every breaking change. This goes against best practices, being highly error-prone.
 
-We expect edx-event-bus-kafka to change more frequently than `confluent-kafka`, which is why we are more willing to adopt the optional dependency strategy for the latter.
+We expect edx-event-bus-kafka to change more frequently than ``confluent-kafka``, which is why we are more willing to adopt the optional dependency strategy for the latter.
 
-* Keep both `confluent-kafka` and `edx-event-bus-kafka` as a required dependencies
+* Keep both ``confluent-kafka`` and ``edx-event-bus-kafka`` as a required dependencies
 
 While not necessarily causing problems for edx.org, this would break many community-hosted Open edX instances as well as many development environments.

--- a/docs/decisions/0005-optional-import-of-confluent-kafka.rst
+++ b/docs/decisions/0005-optional-import-of-confluent-kafka.rst
@@ -64,6 +64,6 @@ This would require developers to install ``edx-event-bus-kafka`` separately when
 
 We expect edx-event-bus-kafka to change more frequently than ``confluent-kafka``, which is why we are more willing to adopt the optional dependency strategy for the latter.
 
-* Keep both ``confluent-kafka`` and ``edx-event-bus-kafka`` as a required dependencies
+* Keep both ``confluent-kafka`` and ``edx-event-bus-kafka`` as required dependencies
 
 While not necessarily causing problems for edx.org, this would break many community-hosted Open edX instances as well as many development environments.

--- a/edx_event_bus_kafka/config.py
+++ b/edx_event_bus_kafka/config.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 from django.conf import settings
 
+# See https://github.com/openedx/event-bus-kafka/blob/main/docs/decisions/0005-optional-import-of-confluent-kafka.rst
 try:
     import confluent_kafka
     from confluent_kafka.schema_registry import SchemaRegistryClient

--- a/edx_event_bus_kafka/config.py
+++ b/edx_event_bus_kafka/config.py
@@ -11,7 +11,7 @@ from django.conf import settings
 try:
     import confluent_kafka
     from confluent_kafka.schema_registry import SchemaRegistryClient
-except ImportError:
+except ImportError:  # pragma: no cover
     confluent_kafka = None
 
 
@@ -24,7 +24,7 @@ def create_schema_registry_client():
         None if confluent_kafka library is not available or the settings are invalid.
         SchemaRegistryClient if it is.
     """
-    if not confluent_kafka:
+    if not confluent_kafka:  # pragma: no cover
         warnings.warn('Library confluent-kafka not available. Cannot create schema registry client.')
         return None
 

--- a/edx_event_bus_kafka/consumer/event_consumer.py
+++ b/edx_event_bus_kafka/consumer/event_consumer.py
@@ -22,7 +22,7 @@ try:
     import confluent_kafka
     from confluent_kafka import DeserializingConsumer, KafkaError
     from confluent_kafka.schema_registry.avro import AvroDeserializer
-except ImportError:
+except ImportError:  # pragma: no cover
     confluent_kafka = None
 
 # .. toggle_name: EVENT_BUS_KAFKA_CONSUMERS_ENABLED
@@ -50,7 +50,7 @@ class KafkaEventConsumer:
     """
 
     def __init__(self, topic, group_id, signal):
-        if confluent_kafka is None:
+        if confluent_kafka is None:  # pragma: no cover
             raise Exception('Library confluent-kafka not available. Cannot create event consumer.')
 
         self.topic = topic

--- a/edx_event_bus_kafka/consumer/event_consumer.py
+++ b/edx_event_bus_kafka/consumer/event_consumer.py
@@ -17,6 +17,7 @@ from edx_event_bus_kafka.config import create_schema_registry_client, load_commo
 
 logger = logging.getLogger(__name__)
 
+# See https://github.com/openedx/event-bus-kafka/blob/main/docs/decisions/0005-optional-import-of-confluent-kafka.rst
 try:
     import confluent_kafka
     from confluent_kafka import DeserializingConsumer, KafkaError

--- a/edx_event_bus_kafka/consumer/tests/test_event_consumer.py
+++ b/edx_event_bus_kafka/consumer/tests/test_event_consumer.py
@@ -18,8 +18,8 @@ from edx_event_bus_kafka.management.commands.consume_events import Command
 # See https://github.com/openedx/event-bus-kafka/blob/main/docs/decisions/0005-optional-import-of-confluent-kafka.rst
 try:
     from confluent_kafka.serialization import StringSerializer
-except ImportExcept:
-    pass  # pragma: no cover
+except ImportExcept:  # pragma: no cover
+    pass
 
 
 class FakeMessage:

--- a/edx_event_bus_kafka/consumer/tests/test_event_consumer.py
+++ b/edx_event_bus_kafka/consumer/tests/test_event_consumer.py
@@ -15,11 +15,11 @@ from openedx_events.tooling import OpenEdxPublicSignal
 from edx_event_bus_kafka.consumer.event_consumer import KafkaEventConsumer
 from edx_event_bus_kafka.management.commands.consume_events import Command
 
+# See https://github.com/openedx/event-bus-kafka/blob/main/docs/decisions/0005-optional-import-of-confluent-kafka.rst
 try:
-    import confluent_kafka
     from confluent_kafka.serialization import StringSerializer
 except ImportExcept:
-    confluent_kafka = None
+    pass
 
 
 class FakeMessage:

--- a/edx_event_bus_kafka/consumer/tests/test_event_consumer.py
+++ b/edx_event_bus_kafka/consumer/tests/test_event_consumer.py
@@ -19,7 +19,7 @@ from edx_event_bus_kafka.management.commands.consume_events import Command
 try:
     from confluent_kafka.serialization import StringSerializer
 except ImportExcept:
-    pass
+    pass  # pragma: no cover
 
 
 class FakeMessage:

--- a/edx_event_bus_kafka/publishing/event_producer.py
+++ b/edx_event_bus_kafka/publishing/event_producer.py
@@ -16,6 +16,7 @@ from edx_event_bus_kafka.config import create_schema_registry_client, load_commo
 
 logger = logging.getLogger(__name__)
 
+# See https://github.com/openedx/event-bus-kafka/blob/main/docs/decisions/0005-optional-import-of-confluent-kafka.rst
 try:
     import confluent_kafka
     from confluent_kafka import SerializingProducer

--- a/edx_event_bus_kafka/publishing/event_producer.py
+++ b/edx_event_bus_kafka/publishing/event_producer.py
@@ -21,7 +21,7 @@ try:
     import confluent_kafka
     from confluent_kafka import SerializingProducer
     from confluent_kafka.schema_registry.avro import AvroSerializer
-except ImportError:
+except ImportError:  # pragma: no cover
     confluent_kafka = None
 
 # CloudEvent standard name for the event type header, see
@@ -147,7 +147,7 @@ def get_producer_for_signal(signal: OpenEdxPublicSignal, event_key_field: str):
         remote-config (and in particular does not result in mixed cache/uncached configuration).
         This complexity is being deferred until this becomes a performance issue.
     """
-    if not confluent_kafka:
+    if not confluent_kafka:  # pragma: no cover
         logger.warning('Library confluent-kafka not available. Cannot create event producer.')
         return None
 

--- a/edx_event_bus_kafka/publishing/test_event_producer.py
+++ b/edx_event_bus_kafka/publishing/test_event_producer.py
@@ -18,7 +18,7 @@ import edx_event_bus_kafka.publishing.event_producer as ep
 try:
     from confluent_kafka import SerializingProducer
 except ImportError:
-    pass
+    pass  # pragma: no cover
 
 
 class TestEventProducer(TestCase):

--- a/edx_event_bus_kafka/publishing/test_event_producer.py
+++ b/edx_event_bus_kafka/publishing/test_event_producer.py
@@ -17,8 +17,8 @@ import edx_event_bus_kafka.publishing.event_producer as ep
 # See https://github.com/openedx/event-bus-kafka/blob/main/docs/decisions/0005-optional-import-of-confluent-kafka.rst
 try:
     from confluent_kafka import SerializingProducer
-except ImportError:
-    pass  # pragma: no cover
+except ImportError:  # pragma: no cover
+    pass
 
 
 class TestEventProducer(TestCase):

--- a/edx_event_bus_kafka/publishing/test_event_producer.py
+++ b/edx_event_bus_kafka/publishing/test_event_producer.py
@@ -14,10 +14,11 @@ from openedx_events.learning.data import UserData, UserPersonalData
 
 import edx_event_bus_kafka.publishing.event_producer as ep
 
+# See https://github.com/openedx/event-bus-kafka/blob/main/docs/decisions/0005-optional-import-of-confluent-kafka.rst
 try:
     from confluent_kafka import SerializingProducer
 except ImportError:
-    confluent_kafka = None
+    pass
 
 
 class TestEventProducer(TestCase):


### PR DESCRIPTION
Explain reasoning in ADR 5 and link to it from try-imports. Also, fix some
rST syntax and the ADR title.

**Merge checklist:**
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed