### PR TITLE
temp: sad path poc

### DIFF
--- a/edx_event_bus_kafka/internal/exceptions.py
+++ b/edx_event_bus_kafka/internal/exceptions.py
@@ -1,0 +1,6 @@
+class BadConfigurationException(Exception):
+    pass
+
+
+class MissingKeyException(Exception):
+    pass


### PR DESCRIPTION
This is not for actual merging, just for review of the concept of using error topics and standardized logs on the producer side. 

The idea is to first try sending events to an error topic. This is for cases where there may be a serialization problem or a missing primary key field or something. If we cannot send to the error topic either, we log in a standard format. The error topic has a very open schema so we should be able to send events that are malformed in multiple ways to the same error topic.