### PR TITLE
feat!: add KafkaEventConsumer to public API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Change Log
    in this file.  It adheres to the structure of https://keepachangelog.com/ ,
    but in reStructuredText instead of Markdown (for ease of incorporation into
    Sphinx documentation and the PyPI description).
-   
+
    This project adheres to Semantic Versioning (https://semver.org/).
 
 .. There should always be an "Unreleased" section for changes pending release.
@@ -15,6 +15,14 @@ Unreleased
 **********
 
 *
+
+[0.6.3] - 2022-09-08
+********************
+
+Added
+=====
+
+* KafkaEventConsumer is now part of the public API
 
 [0.6.2] - 2022-09-08
 ********************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,12 +16,13 @@ Unreleased
 
 *
 
-[0.6.3] - 2022-09-08
+[0.7.0] - 2022-09-08
 ********************
 
-Added
-=====
+Changed
+=======
 
+* **Breaking changes** ``EventProducerKafka`` is now ``KafkaEventProducer``
 * KafkaEventConsumer is now part of the public API
 
 [0.6.2] - 2022-09-08

--- a/edx_event_bus_kafka/__init__.py
+++ b/edx_event_bus_kafka/__init__.py
@@ -9,4 +9,4 @@ See ADR ``docs/decisions/0006-public-api-and-app-organization.rst`` for the reas
 from edx_event_bus_kafka.internal.consumer import KafkaEventConsumer
 from edx_event_bus_kafka.internal.producer import EventProducerKafka, get_producer
 
-__version__ = '0.6.3'
+__version__ = '0.7.0'

--- a/edx_event_bus_kafka/__init__.py
+++ b/edx_event_bus_kafka/__init__.py
@@ -7,6 +7,6 @@ See ADR ``docs/decisions/0006-public-api-and-app-organization.rst`` for the reas
 """
 
 from edx_event_bus_kafka.internal.consumer import KafkaEventConsumer
-from edx_event_bus_kafka.internal.producer import EventProducerKafka, get_producer
+from edx_event_bus_kafka.internal.producer import KafkaEventProducer, get_producer
 
 __version__ = '0.7.0'

--- a/edx_event_bus_kafka/__init__.py
+++ b/edx_event_bus_kafka/__init__.py
@@ -6,7 +6,7 @@ Public API will be in this module for the most part.
 See ADR ``docs/decisions/0006-public-api-and-app-organization.rst`` for the reasoning.
 """
 
-from edx_event_bus_kafka.internal.producer import EventProducerKafka, get_producer
 from edx_event_bus_kafka.internal.consumer import KafkaEventConsumer
+from edx_event_bus_kafka.internal.producer import EventProducerKafka, get_producer
 
 __version__ = '0.6.3'

--- a/edx_event_bus_kafka/__init__.py
+++ b/edx_event_bus_kafka/__init__.py
@@ -7,5 +7,6 @@ See ADR ``docs/decisions/0006-public-api-and-app-organization.rst`` for the reas
 """
 
 from edx_event_bus_kafka.internal.producer import EventProducerKafka, get_producer
+from edx_event_bus_kafka.internal.consumer import KafkaEventConsumer
 
-__version__ = '0.6.2'
+__version__ = '0.6.3'

--- a/edx_event_bus_kafka/internal/producer.py
+++ b/edx_event_bus_kafka/internal/producer.py
@@ -157,7 +157,7 @@ def get_serializers(signal: OpenEdxPublicSignal, event_key_field: str):
     return key_serializer, value_serializer
 
 
-class EventProducerKafka():
+class KafkaEventProducer():
     """
     API singleton for event production to Kafka.
 
@@ -221,7 +221,7 @@ class EventProducerKafka():
         self.producer.flush(-1)
 
 
-def poll_indefinitely(api_weakref: EventProducerKafka):
+def poll_indefinitely(api_weakref: KafkaEventProducer):
     """
     Poll the producer indefinitely to ensure delivery/stats/etc. callbacks are triggered.
 
@@ -230,7 +230,7 @@ def poll_indefinitely(api_weakref: EventProducerKafka):
     See ADR for more information:
     https://github.com/openedx/event-bus-kafka/blob/main/docs/decisions/0007-producer-polling.rst
     """
-    # The reason we hold a weakref to the whole EventProducerKafka and
+    # The reason we hold a weakref to the whole KafkaEventProducer and
     # not directly to the Producer itself is that you just can't make
     # a weakref to the latter (perhaps because it's a C object.)
 
@@ -267,7 +267,7 @@ def poll_indefinitely(api_weakref: EventProducerKafka):
 # outbound-message queue and threads. The use of this cache allows the
 # producer to be long-lived.
 @lru_cache  # will just be one cache entry, in practice
-def get_producer() -> Optional[EventProducerKafka]:
+def get_producer() -> Optional[KafkaEventProducer]:
     """
     Create or retrieve Producer API singleton.
 
@@ -281,7 +281,7 @@ def get_producer() -> Optional[EventProducerKafka]:
     if producer_settings is None:
         return None
 
-    return EventProducerKafka(Producer(producer_settings))
+    return KafkaEventProducer(Producer(producer_settings))
 
 
 def on_event_deliver(err, evt):

--- a/edx_event_bus_kafka/internal/tests/test_producer.py
+++ b/edx_event_bus_kafka/internal/tests/test_producer.py
@@ -94,7 +94,7 @@ class TestEventProducer(TestCase):
                 EVENT_BUS_KAFKA_API_KEY='some_other_key',
                 EVENT_BUS_KAFKA_API_SECRET='some_other_secret',
         ):
-            assert isinstance(ep.get_producer(), ep.EventProducerKafka)
+            assert isinstance(ep.get_producer(), ep.KafkaEventProducer)
 
     @patch('edx_event_bus_kafka.internal.producer.logger')
     def test_on_event_deliver(self, mock_logger):
@@ -153,7 +153,7 @@ class TestEventProducer(TestCase):
             call_count += 1
 
         mock_producer = Mock(**{'poll.side_effect': increment_call_count})
-        producer_api = ep.EventProducerKafka(mock_producer)  # Created, starts polling
+        producer_api = ep.KafkaEventProducer(mock_producer)  # Created, starts polling
 
         # Allow a little time to pass and check that the mock poll has been called
         time.sleep(1.0)
@@ -186,7 +186,7 @@ class TestEventProducer(TestCase):
                 raise Exception("Exercise error handler on first iteration")
 
         mock_producer = Mock(**{'poll.side_effect': increment_call_count})
-        producer_api = ep.EventProducerKafka(mock_producer)  # Created, starts polling
+        producer_api = ep.KafkaEventProducer(mock_producer)  # Created, starts polling
 
         # Allow a little time to pass and check that the mock poll has been called
         time.sleep(1.0)


### PR DESCRIPTION
Two changes, though I can be convinced to split them out.
First makes KafkaEventConsumer public
Second renames EventProducerKafka to KafkaEventProducer to be consistent.

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] Noted any: Concerns, dependencies, deadlines, tickets, testing instructions