### PR TITLE
fix: send schema to fully-qualified topic when using topic prefixes

### DIFF
--- a/edx_event_bus_kafka/internal/producer.py
+++ b/edx_event_bus_kafka/internal/producer.py
@@ -191,14 +191,14 @@ class KafkaEventProducer():
               string naming the dictionary keys to descend)
             event_data: The event data (kwargs) sent to the signal
         """
+        full_topic = get_full_topic(topic)
+
         event_key = extract_event_key(event_data, event_key_field)
         headers = {EVENT_TYPE_HEADER_KEY: signal.event_type}
 
         key_serializer, value_serializer = get_serializers(signal, event_key_field)
-        key_bytes = key_serializer(event_key, SerializationContext(topic, MessageField.KEY, headers))
-        value_bytes = value_serializer(event_data, SerializationContext(topic, MessageField.VALUE, headers))
-
-        full_topic = get_full_topic(topic)
+        key_bytes = key_serializer(event_key, SerializationContext(full_topic, MessageField.KEY, headers))
+        value_bytes = value_serializer(event_data, SerializationContext(full_topic, MessageField.VALUE, headers))
 
         self.producer.produce(
             full_topic, key=key_bytes, value=value_bytes, headers=headers, on_delivery=on_event_deliver,

--- a/edx_event_bus_kafka/internal/producer.py
+++ b/edx_event_bus_kafka/internal/producer.py
@@ -257,7 +257,6 @@ def poll_indefinitely(api_weakref: KafkaEventProducer):
             # we make when producing an event. The call in this loop could be excessively noisy,
             # so just debug-log it.
             logger.debug("Event bus producer polling loop encountered exception (continuing)", exc_info=True)
-            logger.debug("lalalala")
         finally:
             # Get rid of that strong ref again
             api_object = None

--- a/edx_event_bus_kafka/internal/producer.py
+++ b/edx_event_bus_kafka/internal/producer.py
@@ -257,6 +257,7 @@ def poll_indefinitely(api_weakref: KafkaEventProducer):
             # we make when producing an event. The call in this loop could be excessively noisy,
             # so just debug-log it.
             logger.debug("Event bus producer polling loop encountered exception (continuing)", exc_info=True)
+            logger.debug("lalalala")
         finally:
             # Get rid of that strong ref again
             api_object = None

--- a/edx_event_bus_kafka/internal/tests/test_producer.py
+++ b/edx_event_bus_kafka/internal/tests/test_producer.py
@@ -6,7 +6,7 @@ import gc
 import time
 import warnings
 from unittest import TestCase
-from unittest.mock import Mock, patch
+from unittest.mock import call, Mock, patch
 
 import openedx_events.learning.signals
 import pytest
@@ -192,3 +192,28 @@ class TestEventProducer(TestCase):
         time.sleep(1.0)
         assert call_count >= 3  # some small value; would actually be about 20
         print(producer_api)  # Use the value here to ensure it isn't GC'd early
+
+    @override_settings(EVENT_BUS_TOPIC_PREFIX='stage')
+    @override_settings(EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL='http://localhost:12345')
+    @override_settings(EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321')
+    @patch('edx_event_bus_kafka.internal.producer.SerializationContext')
+    def test_serialize_and_produce_to_same_topic(self, mock_context):
+        producer_api = ep.get_producer()
+        with patch('edx_event_bus_kafka.internal.producer.AvroSerializer',
+                   return_value=lambda _x, _y: b'bytes-here'):
+            with patch.object(producer_api, 'producer', autospec=True) as mock_producer:
+                producer_api.send(
+                    signal=self.signal, topic='user-stuff',
+                    event_key_field='user.id', event_data=self.event_data
+                )
+
+        mock_context.assert_has_calls([
+            call('stage-user-stuff', 'key', {'ce_type': 'org.openedx.learning.auth.session.login.completed.v1'}),
+            call('stage-user-stuff', 'value', {'ce_type': 'org.openedx.learning.auth.session.login.completed.v1'}),
+        ])
+        assert mock_context.call_count == 2
+        mock_producer.produce.assert_called_once_with(
+            'stage-user-stuff', key=b'bytes-here', value=b'bytes-here',
+            on_delivery=ep.on_event_deliver,
+            headers={'ce_type': 'org.openedx.learning.auth.session.login.completed.v1'},
+        )


### PR DESCRIPTION
The event schema is sent to the topic passed to the SerializationContext used in the serialization call. We were using the un-prefixed topic, which meant that events were getting sent to topics with no schemas, making them unreadable in the Confluent UI. This fixes this issue by passing the fully-qualified topic to the SerializationContext objects.



**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] Noted any: Concerns, dependencies, deadlines, tickets, testing instructions