### PR TITLE
feat: Change `EVENT_BUS_KAFKA_CONSUMERS_ENABLED` default to True

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,14 @@ Unreleased
 
 * Removed manual monitoring since New Relic tracks these now.
 
+[1.2.0] - 2022-10-13
+********************
+
+Changed
+=======
+
+* ``EVENT_BUS_KAFKA_CONSUMERS_ENABLED`` now defaults to True instead of False
+
 [1.1.0] - 2022-10-06
 ********************
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Change Log
 Unreleased
 **********
 
-* Removed manual monitoring since New Relic tracks these now.
+*
 
 [1.2.0] - 2022-10-13
 ********************
@@ -23,6 +23,7 @@ Changed
 =======
 
 * ``EVENT_BUS_KAFKA_CONSUMERS_ENABLED`` now defaults to True instead of False
+* Removed manual monitoring since New Relic tracks these now.
 
 [1.1.0] - 2022-10-06
 ********************

--- a/edx_event_bus_kafka/__init__.py
+++ b/edx_event_bus_kafka/__init__.py
@@ -9,4 +9,4 @@ See ADR ``docs/decisions/0006-public-api-and-app-organization.rst`` for the reas
 from edx_event_bus_kafka.internal.consumer import KafkaEventConsumer
 from edx_event_bus_kafka.internal.producer import KafkaEventProducer, get_producer
 
-__version__ = '1.1.0'
+__version__ = '1.2.0'


### PR DESCRIPTION
This was originally intended as a rollout switch, but running the consumer already requires invoking a management command. Defaulting to True makes this an emergency kill-switch, which is more plausibly useful.

Remove ticket link that is now outdated.


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
- [x] Noted any: Concerns, dependencies, deadlines, tickets, testing instructions
