### PR TITLE
feat: Remove background_task decorator.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Change Log
 Unreleased
 **********
 
-*
+* Removed manual monitoring since New Relic tracks these now.
 
 [1.1.0] - 2022-10-06
 ********************

--- a/edx_event_bus_kafka/internal/consumer.py
+++ b/edx_event_bus_kafka/internal/consumer.py
@@ -7,7 +7,6 @@ import logging
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.dispatch import receiver
-from edx_django_utils.monitoring import background_task
 from edx_toggles.toggles import SettingToggle
 from openedx_events.event_bus.avro.deserializer import AvroSignalDeserializer
 from openedx_events.learning.data import UserData
@@ -115,7 +114,6 @@ class KafkaEventConsumer:
             self.consumer.close()
             logger.info("Committing final offsets")
 
-    @background_task()
     def process_single_message(self, msg):
         """
         Emit signal with message data


### PR DESCRIPTION
New Relic released an update that handles message consumption transactions, and this logging was redundant.

Also, it didn't work.


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
- [x] Noted any: Concerns, dependencies, deadlines, tickets, testing instructions
