### PR TITLE
fix: Don't look up signal a second time in consumer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Change Log
 Unreleased
 **********
 
-*
+* Remove redundant lookup of signal in consumer loop (should not have any effect)
 
 [1.2.0] - 2022-10-13
 ********************

--- a/edx_event_bus_kafka/internal/consumer.py
+++ b/edx_event_bus_kafka/internal/consumer.py
@@ -157,21 +157,17 @@ class KafkaEventConsumer:
         # TODO (EventBus): Figure out who is doing the encoding and get the
         #  right one instead of just guessing utf-8
         event_type_str = event_type.decode("utf-8")
-        try:
 
-            # If we get a message with the wrong signal encoding, we do not want to send it along.
-            # TODO (EventBus): Handle this particular sad path more gracefully.
-            if event_type_str != self.signal.event_type:
-                logger.error(
-                    f"Signal types do not match. Expected {self.signal.event_type}."
-                    f"Received message of type {event_type_str}."
-                )
-                return
+        # If we get a message with the wrong signal encoding, we do not want to send it along.
+        # TODO (EventBus): Handle this particular sad path more gracefully.
+        if event_type_str != self.signal.event_type:
+            logger.error(
+                f"Signal types do not match. Expected {self.signal.event_type}."
+                f"Received message of type {event_type_str}."
+            )
+            return
 
-            signal = OpenEdxPublicSignal.get_signal_by_type(event_type_str)
-            signal.send_event(**msg.value())
-        except KeyError:
-            logger.exception(f"Signal not found: {event_type_str}")
+        self.signal.send_event(**msg.value())
 
 
 class ConsumeEventsCommand(BaseCommand):

--- a/edx_event_bus_kafka/internal/tests/test_consumer.py
+++ b/edx_event_bus_kafka/internal/tests/test_consumer.py
@@ -147,7 +147,7 @@ class TestEmitSignals(TestCase):
         assert not self.mock_signal.send_event.called
 
     @patch('edx_event_bus_kafka.internal.consumer.logger', autospec=True)
-    def test_unwanted_types(self, mock_logger):
+    def test_unexpected_signal_type_in_header(self, mock_logger):
         msg = copy.copy(self.normal_message)
         msg._headers = [  # pylint: disable=protected-access
             ['ce_type', b'xxxx']


### PR DESCRIPTION
The consumer is configured with a signal to listen for, and while the `emit_signals_from_message` was validating that messages matched the signal, it was then doing a lookup on the event type anyhow. I think this was harmless but redundant, so this removes that lookup.

Also, improve consumer tests, mostly by adding assertions on logging (done as a separate commit, but will be squashed.)

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [x] Noted any: Concerns, dependencies, deadlines, tickets, testing instructions
