### PR TITLE
feat: upgrade openedx-events to 3.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,15 +19,12 @@ Unreleased
 [1.3.0] - 2022-10-13
 ********************
 
-* Upgrade openedx-events. When AvroSignalSerializer gets event schemas, it will
-get whatever is currently defined in openedx-events, so this will update the
-COURSE_CATALOG_EVENT_CHANGED schema (dropping `effort` field)
-
 Changed
 =======
 
-* ``EVENT_BUS_KAFKA_CONSUMERS_ENABLED`` now defaults to True instead of False
-* Removed manual monitoring since New Relic tracks these now.
+* Upgrade openedx-events. When AvroSignalSerializer gets event schemas, it will
+get whatever is currently defined in openedx-events, so this will update the
+COURSE_CATALOG_EVENT_CHANGED schema (dropping `effort` field)
 
 [1.2.0] - 2022-10-13
 ********************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,9 +22,7 @@ Unreleased
 Changed
 =======
 
-* Upgrade openedx-events. When AvroSignalSerializer gets event schemas, it will
-get whatever is currently defined in openedx-events, so this will update the
-COURSE_CATALOG_EVENT_CHANGED schema (dropping `effort` field)
+* Upgrade openedx-events. When AvroSignalSerializer gets event schemas, it will get whatever is currently defined in openedx-events, so this will update the COURSE_CATALOG_EVENT_CHANGED schema (dropping `effort` field)
 
 [1.2.0] - 2022-10-13
 ********************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,19 @@ Unreleased
 
 *
 
+[1.3.0] - 2022-10-13
+********************
+
+* Upgrade openedx-events. When AvroSignalSerializer gets event schemas, it will
+get whatever is currently defined in openedx-events, so this will update the
+COURSE_CATALOG_EVENT_CHANGED schema (dropping `effort` field)
+
+Changed
+=======
+
+* ``EVENT_BUS_KAFKA_CONSUMERS_ENABLED`` now defaults to True instead of False
+* Removed manual monitoring since New Relic tracks these now.
+
 [1.2.0] - 2022-10-13
 ********************
 

--- a/edx_event_bus_kafka/__init__.py
+++ b/edx_event_bus_kafka/__init__.py
@@ -9,4 +9,4 @@ See ADR ``docs/decisions/0006-public-api-and-app-organization.rst`` for the reas
 from edx_event_bus_kafka.internal.consumer import KafkaEventConsumer
 from edx_event_bus_kafka.internal.producer import KafkaEventProducer, get_producer
 
-__version__ = '1.2.0'
+__version__ = '1.3.0'

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -48,7 +48,7 @@ markupsafe==2.1.1
     # via jinja2
 newrelic==8.2.1
     # via edx-django-utils
-openedx-events==2.0.0
+openedx-events==3.0.0
     # via -r requirements/base.in
 pbr==5.10.0
     # via stevedore

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -196,7 +196,7 @@ newrelic==8.2.1
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
-openedx-events==2.0.0
+openedx-events==3.0.0
     # via -r requirements/quality.txt
 packaging==21.3
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -138,7 +138,7 @@ newrelic==8.2.1
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-openedx-events==2.0.0
+openedx-events==3.0.0
     # via -r requirements/test.txt
 packaging==21.3
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -141,7 +141,7 @@ newrelic==8.2.1
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-openedx-events==2.0.0
+openedx-events==3.0.0
     # via -r requirements/test.txt
 packaging==21.3
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -85,7 +85,7 @@ newrelic==8.2.1
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-openedx-events==2.0.0
+openedx-events==3.0.0
     # via -r requirements/base.txt
 packaging==21.3
     # via pytest


### PR DESCRIPTION
Doing this separately to bring in a change to the COURSE_CATALOG_INFO_CHANGED event schema. The schema is generated and sent to Kafka by code in this repository, so in order to actually start using any schema changes we need to upgrade this library first. 

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] Noted any: Concerns, dependencies, deadlines, tickets, testing instructions