### PR TITLE
fix: Explicitly encode message header values as UTF-8

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Unreleased
 **********
 
 * Remove redundant lookup of signal in consumer loop (should not have any effect)
+* Explicitly encode message header values as UTF-8 (no change in behavior)
 
 [1.3.0] - 2022-10-20
 ********************

--- a/edx_event_bus_kafka/internal/consumer.py
+++ b/edx_event_bus_kafka/internal/consumer.py
@@ -154,8 +154,7 @@ class KafkaEventConsumer:
 
         event_type = event_types[0]
 
-        # TODO (EventBus): Figure out who is doing the encoding and get the
-        #  right one instead of just guessing utf-8
+        # CloudEvents specifies using UTF-8 for header values, so let's be explicit.
         event_type_str = event_type.decode("utf-8")
 
         # If we get a message with the wrong signal encoding, we do not want to send it along.

--- a/edx_event_bus_kafka/internal/producer.py
+++ b/edx_event_bus_kafka/internal/producer.py
@@ -194,7 +194,9 @@ class KafkaEventProducer():
         full_topic = get_full_topic(topic)
 
         event_key = extract_event_key(event_data, event_key_field)
-        headers = {EVENT_TYPE_HEADER_KEY: signal.event_type}
+        # Dictionary (or list of key/value tuples) where keys are strings and values are binary.
+        # CloudEvents specifies using UTF-8; that should be the default, but let's make it explicit.
+        headers = {EVENT_TYPE_HEADER_KEY: signal.event_type.encode("utf-8")}
 
         key_serializer, value_serializer = get_serializers(signal, event_key_field)
         key_bytes = key_serializer(event_key, SerializationContext(full_topic, MessageField.KEY, headers))

--- a/edx_event_bus_kafka/internal/tests/test_producer.py
+++ b/edx_event_bus_kafka/internal/tests/test_producer.py
@@ -138,7 +138,7 @@ class TestEventProducer(TestCase):
         mock_producer.produce.assert_called_once_with(
             'prod-user-stuff', key=b'key-bytes-here', value=b'value-bytes-here',
             on_delivery=ep.on_event_deliver,
-            headers={'ce_type': 'org.openedx.learning.auth.session.login.completed.v1'},
+            headers={'ce_type': b'org.openedx.learning.auth.session.login.completed.v1'},
         )
 
     @override_settings(EVENT_BUS_KAFKA_POLL_INTERVAL_SEC=0.05)
@@ -208,12 +208,12 @@ class TestEventProducer(TestCase):
                 )
 
         mock_context.assert_has_calls([
-            call('stage-user-stuff', 'key', {'ce_type': 'org.openedx.learning.auth.session.login.completed.v1'}),
-            call('stage-user-stuff', 'value', {'ce_type': 'org.openedx.learning.auth.session.login.completed.v1'}),
+            call('stage-user-stuff', 'key', {'ce_type': b'org.openedx.learning.auth.session.login.completed.v1'}),
+            call('stage-user-stuff', 'value', {'ce_type': b'org.openedx.learning.auth.session.login.completed.v1'}),
         ])
         assert mock_context.call_count == 2
         mock_producer.produce.assert_called_once_with(
             'stage-user-stuff', key=b'bytes-here', value=b'bytes-here',
             on_delivery=ep.on_event_deliver,
-            headers={'ce_type': 'org.openedx.learning.auth.session.login.completed.v1'},
+            headers={'ce_type': b'org.openedx.learning.auth.session.login.completed.v1'},
         )


### PR DESCRIPTION
This should not cause any change in behavior -- it just pins the existing behavior as explicit and adds a comment explaining it.


**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
- [x] Noted any: Concerns, dependencies, deadlines, tickets, testing instructions
