### PR TITLE
feat: start processing messages at latest offset

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,7 @@ Unreleased
 
 Changed
 =======
-* Remove auto.offset.reset: earliest from consumer (new consumer groups will now consume only messages that are sent after the group was initialized)
+* Remove override of auto.offset.reset on consumer (which will default to "latest"). New consumer groups will consume only messages that are sent after the group was initialized.
 * Remove redundant lookup of signal in consumer loop (should not have any effect)
 
 [1.3.0] - 2022-10-20

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 **********
 
+[1.4.0] - 2022-10-21
+********************
+
+Changed
+=======
+* Remove auto.offset.reset: earliest from consumer (new consumer groups will now consume only messages that are sent after the group was initialized)
 * Remove redundant lookup of signal in consumer loop (should not have any effect)
 
 [1.3.0] - 2022-10-20

--- a/edx_event_bus_kafka/__init__.py
+++ b/edx_event_bus_kafka/__init__.py
@@ -9,4 +9,4 @@ See ADR ``docs/decisions/0006-public-api-and-app-organization.rst`` for the reas
 from edx_event_bus_kafka.internal.consumer import KafkaEventConsumer
 from edx_event_bus_kafka.internal.producer import KafkaEventProducer, get_producer
 
-__version__ = '1.3.0'
+__version__ = '1.4.0'

--- a/edx_event_bus_kafka/internal/consumer.py
+++ b/edx_event_bus_kafka/internal/consumer.py
@@ -88,7 +88,6 @@ class KafkaEventConsumer:
             'value.deserializer': AvroDeserializer(schema_str=signal_deserializer.schema_string(),
                                                    schema_registry_client=schema_registry_client,
                                                    from_dict=inner_from_dict),
-            'auto.offset.reset': 'earliest'
         })
 
         return DeserializingConsumer(consumer_config)


### PR DESCRIPTION
New consumers will only processes messages that have been added to the topic since the consumer group was spun up. This will prevent new consumers from trying to process a massive backlog of events that have been publishing for a while.

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] Noted any: Concerns, dependencies, deadlines, tickets, testing instructions