### PR TITLE
feat: log full event data on all errors in producing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,15 @@ Change Log
 Unreleased
 **********
 
+[1.5.0] - 2022-10-26
+********************
+
+Changed
+=======
+* Remove redundant lookup of signal in consumer loop (should not have any effect)
+* Explicitly encode message header values as UTF-8 (no change in behavior)
+* Log full event data on all producer errors
+
 [1.4.3] - 2022-10-31
 ********************
 
@@ -41,6 +50,7 @@ Fixed
 
 Changed
 =======
+
 * Remove override of auto.offset.reset on consumer (which will default to "latest"). New consumer groups will consume only messages that are sent after the group was initialized.
 * Remove redundant lookup of signal in consumer loop (should not have any effect)
 * Explicitly encode message header values as UTF-8 (no change in behavior)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,8 +19,6 @@ Unreleased
 
 Changed
 =======
-* Remove redundant lookup of signal in consumer loop (should not have any effect)
-* Explicitly encode message header values as UTF-8 (no change in behavior)
 * Log full event data on all producer errors
 
 [1.4.3] - 2022-10-31
@@ -50,7 +48,6 @@ Fixed
 
 Changed
 =======
-
 * Remove override of auto.offset.reset on consumer (which will default to "latest"). New consumer groups will consume only messages that are sent after the group was initialized.
 * Remove redundant lookup of signal in consumer loop (should not have any effect)
 * Explicitly encode message header values as UTF-8 (no change in behavior)

--- a/docs/decisions/0008-baseline-error-handling-for-producer.rst
+++ b/docs/decisions/0008-baseline-error-handling-for-producer.rst
@@ -1,0 +1,30 @@
+8. Baseline error handling for the event bus
+############################################
+
+Status
+******
+
+Provisional
+
+Context
+*******
+
+There are numerous strategies for error handling in Kafka, variously optimized for different goals (consistency, reliability, etc.). Some error-handling is built in to the confluent-kafka library, such as a built-in mechanism for automatically retrying messages a specified number of times when the producer is unable to reach the server. Other errors may occur outside the Kafka code, for example when trying to extract an event key from an event data dictionary.
+
+Decisions
+*********
+
+- When dealing with errors in sending events to the event bus, we will prioritize reliability while ensuring that no events are irretrievably dropped.
+- Failing to send an event to the event bus will not fail the request.
+- We will catch exceptions and log the full event data in the error message in a consistent, parseable way.
+- We will also send errors to the monitoring system, although the logs would be required to learn specifics about the message.
+- We will defer any idea of using a retry queue.
+- Note that this decision does not currently cover how we will handle errors on the consumer.
+
+Consequences
+************
+- There may be inconsistencies in data between producing and consuming services when events are not sent.
+- In rare cases such as server crashes some events could still conceivably be irretrievable.
+- Resending failed events may require retrieving and parsing server logs. If other events have been successfully processed in the meantime, these resent events may be processed out of order.
+- It will be up to the developer to determine how to resend errored events.
+- Monitoring may still be used to alert when events are not being sent

--- a/edx_event_bus_kafka/__init__.py
+++ b/edx_event_bus_kafka/__init__.py
@@ -9,4 +9,4 @@ See ADR ``docs/decisions/0006-public-api-and-app-organization.rst`` for the reas
 from edx_event_bus_kafka.internal.consumer import KafkaEventConsumer
 from edx_event_bus_kafka.internal.producer import KafkaEventProducer, get_producer
 
-__version__ = '1.4.3'
+__version__ = '1.5.0'

--- a/edx_event_bus_kafka/internal/producer.py
+++ b/edx_event_bus_kafka/internal/producer.py
@@ -191,7 +191,7 @@ class ProducingContext:
 
     def __repr__(self):
         """Create a logging-friendly string"""
-        return " ".join([f"{key}={value!r}" for key, value in attr.asdict(self).items()])
+        return " ".join([f"{key}={value!r}" for key, value in attr.asdict(self, recurse=False).items()])
 
     def on_event_deliver(self, err, evt):
         """

--- a/edx_event_bus_kafka/internal/tests/test_producer.py
+++ b/edx_event_bus_kafka/internal/tests/test_producer.py
@@ -172,7 +172,7 @@ class TestEventProducer(TestCase):
                               event_data={'test_data': SubTestData0(sub_name="name", course_id="id")})
 
         (error_string,) = mock_logger.exception.call_args.args
-        assert "event_data={'test_data': {'sub_name': 'name', 'course_id': 'id'}}" in error_string
+        assert "event_data={'test_data': SubTestData0(sub_name='name', course_id='id')}" in error_string
         assert "signal=<OpenEdxPublicSignal: simple.signal>" in error_string
         assert "initial_topic='topic'" in error_string
         assert "full_topic='dev-topic'" in error_string
@@ -201,7 +201,7 @@ class TestEventProducer(TestCase):
                                   event_data={'test_data': SubTestData0(sub_name="name", course_id="ABCx")})
 
         (error_string,) = mock_logger.exception.call_args.args
-        assert "event_data={'test_data': {'sub_name': 'name', 'course_id': 'ABCx'}}" in error_string
+        assert "event_data={'test_data': SubTestData0(sub_name='name', course_id='ABCx')}" in error_string
         assert "signal=<OpenEdxPublicSignal: simple.signal>" in error_string
         assert "initial_topic='topic'" in error_string
         assert "full_topic='dev-topic'" in error_string


### PR DESCRIPTION
Include all event data when logging errors in producing so if necessary dropped events can be replayed from the logs.

Issue: https://github.com/openedx/event-bus-kafka/issues/45



**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] Noted any: Concerns, dependencies, deadlines, tickets, testing instructions