### PR TITLE
docs: Update manual testing doc: consumer first; separate halves; rm settings

### DIFF
--- a/docs/how_tos/manual_testing.rst
+++ b/docs/how_tos/manual_testing.rst
@@ -20,13 +20,13 @@ Setting up for testing
 Testing the consumer
 ====================
 
-   - Run the example command listed in the ``edx_event_bus_kafka.consumer.event_consumer.ConsumeEventsCommand`` docstring
-   - The consumer may not read older events from the topic—and it never will for the first run of a topic/group pair—so it needs to be started first in general.
-   - Once an event comes in, expect to see output that ends with a line containing "Received SESSION_LOGIN_COMPLETED signal with user_data"
+- Run the example command listed in the ``edx_event_bus_kafka.consumer.event_consumer.ConsumeEventsCommand`` docstring
+- The consumer may not read older events from the topic—and it never will for the first run of a topic/group pair—so it needs to be started first in general.
+- Once an event comes in, expect to see output that ends with a line containing "Received SESSION_LOGIN_COMPLETED signal with user_data"
 
 Testing the producer
 ====================
 
-   - Run the example command listed in the ``edx_event_bus_kafka.management.commands.produce_event.Command`` docstring
-   - Expect to see output that ends with a line containing "Event delivered to topic"
-   - Go to the topic that was created and then into the Messages tab; select offset=0 to make sure you can see messages that were sent before you had the UI open.
+- Run the example command listed in the ``edx_event_bus_kafka.management.commands.produce_event.Command`` docstring
+- Expect to see output that ends with a line containing "Event delivered to topic"
+- Go to the topic that was created and then into the Messages tab; select offset=0 to make sure you can see messages that were sent before you had the UI open.

--- a/docs/how_tos/manual_testing.rst
+++ b/docs/how_tos/manual_testing.rst
@@ -6,30 +6,24 @@ The producer can be tested manually against a Kafka running in devstack.
 #. Make or refresh a copy of this repo where it can be seen from inside devstack: ``rsync -sax -delete ./ ../src/event-bus-kafka/``
 #. In devstack, start Kafka and the control webapp: ``make dev.up.kafka-control-center`` and watch ``make dev.logs.kafka-control-center`` until server is up and happy (may take a few minutes; watch for ``INFO Kafka startTimeMs``)
 #. Load the control center UI: http://localhost:9021/clusters and wait for the cluster to become healthy
-#. In edx-platform's ``cms/envs/common.py``:
-
-   - Add ``'edx_event_bus_kafka'`` to the ``INSTALLED_APPS`` list
-   - Add the following::
-
-       EVENT_BUS_KAFKA_CONSUMERS_ENABLED = True
-       EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS = "edx.devstack.kafka:29092"
-       EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL = "http://edx.devstack.schema-registry:8081"
+#. In edx-platform's ``cms/envs/common.py``, add ``'edx_event_bus_kafka'`` to the ``INSTALLED_APPS`` list
 
 #. In devstack, run ``make devpi-up studio-up-without-deps-shell`` to bring up Studio with a shell.
 #. In the Studio shell, run ``pip install -e /edx/src/event-bus-kafka``
 #. In the Studio shell, run ``pip install 'confluent_kafka[avro,schema-registry]'`` (necessary external dependency)
+#. Start the consumer:
+
+   - Run the example command listed in the ``edx_event_bus_kafka.consumer.event_consumer.ConsumeEventsCommand`` docstring
+   - The consumer may not read older events from the topic—and it never will for the first run of a topic/group pair—so it needs to be started first in general.
+   - Once an event comes in, expect to see output that ends with a line containing "Received SESSION_LOGIN_COMPLETED signal with user_data"
+
 #. Test the producer:
 
    - Run the example command listed in the ``edx_event_bus_kafka.management.commands.produce_event.Command`` docstring
    - Expect to see output that ends with a line containing "Event delivered to topic"
    - Go to the topic that was created and then into the Messages tab; select offset=0 to make sure you can see messages that were sent before you had the UI open.
 
-#. Test the consumer:
-
-   - Run the example command listed in the ``edx_event_bus_kafka.consumer.event_consumer.ConsumeEventsCommand`` docstring
-   - Expect to see output that ends with a line containing "Received SESSION_LOGIN_COMPLETED signal with user_data"
-   - Kill the management command (which would run indefinitely).
-
 #. Rerun rsync after any edits as needed.
+#. When you're done testing, find the consumer process with ``jobs`` and terminate it with ``kill``, since it would otherwise run indefinitely.
 
 (Any IDA should work for testing, but all interactions have to happen inside devstack's networking layer, otherwise Kafka can't talk to itself.)

--- a/docs/how_tos/manual_testing.rst
+++ b/docs/how_tos/manual_testing.rst
@@ -20,8 +20,9 @@ Setting up for testing
 Testing the consumer
 ====================
 
+The consumer may not read older events from the topic—and it never will for the first run of a topic/group pair—so you may need to started it before the producer, or re-run the producer after the consumer is started.
+
 - Run the example command listed in the ``edx_event_bus_kafka.consumer.event_consumer.ConsumeEventsCommand`` docstring
-- The consumer may not read older events from the topic—and it never will for the first run of a topic/group pair—so it needs to be started first in general.
 - Once an event comes in, expect to see output that ends with a line containing "Received SESSION_LOGIN_COMPLETED signal with user_data"
 
 Testing the producer

--- a/docs/how_tos/manual_testing.rst
+++ b/docs/how_tos/manual_testing.rst
@@ -1,29 +1,32 @@
 Manual testing
-==============
+##############
 
 The producer can be tested manually against a Kafka running in devstack.
 
-#. Make or refresh a copy of this repo where it can be seen from inside devstack: ``rsync -sax -delete ./ ../src/event-bus-kafka/``
+Setting up for testing
+======================
+
+#. Make or refresh a copy of this repo where it can be seen from inside devstack: ``rsync -sax -delete ./ ../src/event-bus-kafka/`` (and rerun rsync after any edits as needed)
 #. In devstack, start Kafka and the control webapp: ``make dev.up.kafka-control-center`` and watch ``make dev.logs.kafka-control-center`` until server is up and happy (may take a few minutes; watch for ``INFO Kafka startTimeMs``)
 #. Load the control center UI: http://localhost:9021/clusters and wait for the cluster to become healthy
+#. Create the topic you want to use for testing. For the examples used in the management commands, you'll want to use ``dev-user-login`` with default settings.
 #. In edx-platform's ``cms/envs/common.py``, add ``'edx_event_bus_kafka'`` to the ``INSTALLED_APPS`` list
-
 #. In devstack, run ``make devpi-up studio-up-without-deps-shell`` to bring up Studio with a shell.
 #. In the Studio shell, run ``pip install -e /edx/src/event-bus-kafka``
 #. In the Studio shell, run ``pip install 'confluent_kafka[avro,schema-registry]'`` (necessary external dependency)
-#. Start the consumer:
+
+(Any IDA should work for testing, but all interactions have to happen inside devstack's networking layer, otherwise Kafka can't talk to itself.)
+
+Testing the consumer
+====================
 
    - Run the example command listed in the ``edx_event_bus_kafka.consumer.event_consumer.ConsumeEventsCommand`` docstring
    - The consumer may not read older events from the topic—and it never will for the first run of a topic/group pair—so it needs to be started first in general.
    - Once an event comes in, expect to see output that ends with a line containing "Received SESSION_LOGIN_COMPLETED signal with user_data"
 
-#. Test the producer:
+Testing the producer
+====================
 
    - Run the example command listed in the ``edx_event_bus_kafka.management.commands.produce_event.Command`` docstring
    - Expect to see output that ends with a line containing "Event delivered to topic"
    - Go to the topic that was created and then into the Messages tab; select offset=0 to make sure you can see messages that were sent before you had the UI open.
-
-#. Rerun rsync after any edits as needed.
-#. When you're done testing, find the consumer process with ``jobs`` and terminate it with ``kill``, since it would otherwise run indefinitely.
-
-(Any IDA should work for testing, but all interactions have to happen inside devstack's networking layer, otherwise Kafka can't talk to itself.)

--- a/docs/how_tos/manual_testing.rst
+++ b/docs/how_tos/manual_testing.rst
@@ -28,6 +28,8 @@ The consumer may not read older events from the topic—and it never will for th
 Testing the producer
 ====================
 
+Note: If you're also running the consumer, you'll need to do this in a separate studio shell.
+
 - Run the example command listed in the ``edx_event_bus_kafka.management.commands.produce_event.Command`` docstring
 - Expect to see output that ends with a line containing "Event delivered to topic"
 - Go to the topic that was created and then into the Messages tab; select offset=0 to make sure you can see messages that were sent before you had the UI open.

--- a/edx_event_bus_kafka/internal/consumer.py
+++ b/edx_event_bus_kafka/internal/consumer.py
@@ -238,9 +238,10 @@ class ConsumeEventsCommand(BaseCommand):
     help = """
     Consume messages of specified signal type from a Kafka topic and send their data to that signal.
 
-    example:
+    Example (runs in background)::
+
         python3 manage.py cms consume_events -t user-login -g user-activity-service \
-            -s org.openedx.learning.auth.session.login.completed.v1
+            -s org.openedx.learning.auth.session.login.completed.v1 &
     """
 
     def add_arguments(self, parser):

--- a/edx_event_bus_kafka/internal/consumer.py
+++ b/edx_event_bus_kafka/internal/consumer.py
@@ -246,10 +246,10 @@ class ConsumeEventsCommand(BaseCommand):
     help = """
     Consume messages of specified signal type from a Kafka topic and send their data to that signal.
 
-    Example (runs in background)::
+    Example::
 
         python3 manage.py cms consume_events -t user-login -g user-activity-service \
-            -s org.openedx.learning.auth.session.login.completed.v1 &
+            -s org.openedx.learning.auth.session.login.completed.v1
     """
 
     def add_arguments(self, parser):


### PR DESCRIPTION
- Split out producer/consumer testing into separate sections
- Put consumer before producer to increase chance of success.
  (Mention topic creation issue.)
- Remove Django settings -- these are now in `cms/envs/devstack.py`
- Put both rsync mentions together
- Fix top heading

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
- [x] Noted any: Concerns, dependencies, deadlines, tickets, testing instructions
