### PR TITLE
feat: manually commit every message on consumption

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,14 @@ Change Log
 Unreleased
 **********
 
+[1.7.0] - 2022-11-04
+********************
+
+Changed
+=======
+* Manually manage commits instead of using auto-commit on the consumer
+* Catch Exception instead of BaseException on both producer and consumer
+
 [1.6.0] - 2022-11-04
 ********************
 

--- a/edx_event_bus_kafka/__init__.py
+++ b/edx_event_bus_kafka/__init__.py
@@ -9,4 +9,4 @@ See ADR ``docs/decisions/0006-public-api-and-app-organization.rst`` for the reas
 from edx_event_bus_kafka.internal.consumer import KafkaEventConsumer
 from edx_event_bus_kafka.internal.producer import KafkaEventProducer, get_producer
 
-__version__ = '1.6.0'
+__version__ = '1.7.0'

--- a/edx_event_bus_kafka/internal/consumer.py
+++ b/edx_event_bus_kafka/internal/consumer.py
@@ -102,6 +102,9 @@ class KafkaEventConsumer:
             'value.deserializer': AvroDeserializer(schema_str=signal_deserializer.schema_string(),
                                                    schema_registry_client=schema_registry_client,
                                                    from_dict=inner_from_dict),
+            # turn off auto commit to avoid committing offsets before a message has been fully processed. We will
+            # manually commit after processing
+            'enable.auto.commit': False,
         })
 
         return DeserializingConsumer(consumer_config)
@@ -140,9 +143,11 @@ class KafkaEventConsumer:
                 msg = None
                 try:
                     msg = self.consumer.poll(timeout=CONSUMER_POLL_TIMEOUT)
+                    print(f"My message is {msg}")
                     if msg is not None:
+                        print(f"My message is not null")
                         self.emit_signals_from_message(msg)
-                except BaseException as e:
+                except Exception as e:  # pylint: disable=broad-except
                     self.record_event_consuming_error(run_context, e, msg)
                     # Prevent fast error-looping when no event received from broker. Because
                     # DeserializingConsumer raises rather than returning a Message when it has an
@@ -150,10 +155,14 @@ class KafkaEventConsumer:
                     # slowing down the queue. This is probably close enough, though.
                     if msg is None:
                         time.sleep(POLL_FAILURE_SLEEP)
+                if msg:
+                    # theoretically we could just call consumer.commit() without passing the specific message
+                    # to commit all this consumer's current offset across all partitions since we only process one
+                    # message at a time, but limit it to just the offset/partition of the specified message
+                    # to be super safe
+                    self.consumer.commit(message=msg, asynchronous=False)
         finally:
-            # Close down consumer to commit final offsets.
             self.consumer.close()
-            logger.info("Committing final offsets")
 
     def emit_signals_from_message(self, msg):
         """

--- a/edx_event_bus_kafka/internal/consumer.py
+++ b/edx_event_bus_kafka/internal/consumer.py
@@ -102,8 +102,9 @@ class KafkaEventConsumer:
             'value.deserializer': AvroDeserializer(schema_str=signal_deserializer.schema_string(),
                                                    schema_registry_client=schema_registry_client,
                                                    from_dict=inner_from_dict),
-            # turn off auto commit to avoid committing offsets before a message has been fully processed. We will
-            # manually commit after processing
+            # Turn off auto commit. Auto commit will commit offsets for the entire batch of messages received,
+            # potentially resulting in data loss if some of those messages are not fully processed. See
+            # https://newrelic.com/blog/best-practices/kafka-consumer-config-auto-commit-data-loss
             'enable.auto.commit': False,
         })
 

--- a/edx_event_bus_kafka/internal/consumer.py
+++ b/edx_event_bus_kafka/internal/consumer.py
@@ -143,9 +143,7 @@ class KafkaEventConsumer:
                 msg = None
                 try:
                     msg = self.consumer.poll(timeout=CONSUMER_POLL_TIMEOUT)
-                    print(f"My message is {msg}")
                     if msg is not None:
-                        print(f"My message is not null")
                         self.emit_signals_from_message(msg)
                 except Exception as e:  # pylint: disable=broad-except
                     self.record_event_consuming_error(run_context, e, msg)

--- a/edx_event_bus_kafka/internal/producer.py
+++ b/edx_event_bus_kafka/internal/producer.py
@@ -112,7 +112,7 @@ def descend_avro_schema(serializer_schema: dict, field_path: List[str]) -> dict:
 
             matching = [field for field in field_list if field['name'] == field_name]
             subschema = matching[0]
-        except BaseException as e:
+        except Exception as e:  # pylint: disable=broad-except
             raise Exception(
                 f"Error traversing Avro schema along path {field_path!r}; failed at {field_name!r}."
             ) from e
@@ -276,7 +276,7 @@ class KafkaEventProducer():
             # would never get a delivery callback. That's why there's also a thread calling
             # poll(0) on a regular interval (see `poll_indefinitely`).
             self.producer.poll(0)
-        except BaseException as e:
+        except Exception as e:  # pylint: disable=broad-except
             # Errors caused by the produce call should be handled by the on_delivery callback.
             # Here we might expect serialization errors, or any errors from preparing to produce.
             record_producing_error(e, context)


### PR DESCRIPTION
Issue: https://github.com/openedx/event-bus-kafka/issues/72

Also changes BaseException to Exception when error handling to avoid catching things like KeyboardInterrupt or SystemExit.

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
- [ ] Noted any: Concerns, dependencies, deadlines, tickets, testing instructions