### PR TITLE
feat: Log warning in consumer when receivers fail with error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 **********
 
+[1.8.0] - 2022-11-09
+********************
+Added
+=====
+* Consumer logs a warning for receivers that fail with an exception
+
 [1.7.0] - 2022-11-04
 ********************
 

--- a/edx_event_bus_kafka/__init__.py
+++ b/edx_event_bus_kafka/__init__.py
@@ -9,4 +9,4 @@ See ADR ``docs/decisions/0006-public-api-and-app-organization.rst`` for the reas
 from edx_event_bus_kafka.internal.consumer import KafkaEventConsumer
 from edx_event_bus_kafka.internal.producer import KafkaEventProducer, get_producer
 
-__version__ = '1.7.0'
+__version__ = '1.8.0'


### PR DESCRIPTION
Also includes a foundational commit for improving testing of the signal/receivers.

This is part of https://github.com/openedx/event-bus-kafka/issues/62

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
- [x] Noted any: Concerns, dependencies, deadlines, tickets, testing instructions
