### PR TITLE
feat: Log and record receiver errors the same way as other errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Change Log
 Unreleased
 **********
 
+[1.9.0] - 2022-11-15
+********************
 Changed
 =======
 * Log and record receiver errors the same way as other errors (with offset, partition, etc.)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 **********
 
+Changed
+=======
+* Log and record receiver errors the same way as other errors (with offset, partition, etc.)
+
 [1.8.1] - 2022-11-10
 ********************
 Changed

--- a/edx_event_bus_kafka/__init__.py
+++ b/edx_event_bus_kafka/__init__.py
@@ -9,4 +9,4 @@ See ADR ``docs/decisions/0006-public-api-and-app-organization.rst`` for the reas
 from edx_event_bus_kafka.internal.consumer import KafkaEventConsumer
 from edx_event_bus_kafka.internal.producer import KafkaEventProducer, get_producer
 
-__version__ = '1.8.1'
+__version__ = '1.9.0'

--- a/edx_event_bus_kafka/internal/consumer.py
+++ b/edx_event_bus_kafka/internal/consumer.py
@@ -58,6 +58,12 @@ class UnusableMessageError(Exception):
     """
 
 
+class ReceiverError(Exception):
+    """
+    Indicates that one or more receivers of a signal threw when called.
+    """
+
+
 class KafkaEventConsumer:
     """
     Construct consumer for the given topic, group, and signal. The consumer can then
@@ -203,11 +209,17 @@ class KafkaEventConsumer:
             )
 
         send_results = self.signal.send_event(**msg.value())
-        self.report_receiver_errors(send_results)
+        # Raise an exception if any receivers errored out. This allows logging of the receivers
+        # along with partition, offset, etc. in record_event_consuming_error. Hopefully the
+        # receiver code is idempotent and we can just replay any messages that were involved.
+        self._check_receiver_results(send_results)
 
-    def report_receiver_errors(self, send_results):
+    def _check_receiver_results(self, send_results: list):
         """
-        Takes the list of (receiver, response) pairs and logs a warning if any are errors.
+        Raises exception if any of the receivers produced an exception.
+
+        Arguments:
+            send_results: Output of ``send_events``, a list of ``(receiver, response)`` tuples.
         """
         error_list = []
         for receiver, response in send_results:
@@ -221,10 +233,11 @@ class KafkaEventConsumer:
             except AttributeError:
                 receiver_name = str(receiver)
 
+            # The stack traces are already logged by django.dispatcher, so just the error message is fine.
             error_list.append(f"{receiver_name}={response!r}")
 
         if len(error_list) > 0:
-            logger.warning(
+            raise ReceiverError(
                 f"{len(error_list)} receiver(s) out of {len(send_results)} "
                 f"produced errors when handling signal {self.signal}: {', '.join(error_list)}"
             )

--- a/edx_event_bus_kafka/internal/consumer.py
+++ b/edx_event_bus_kafka/internal/consumer.py
@@ -60,7 +60,7 @@ class UnusableMessageError(Exception):
 
 class ReceiverError(Exception):
     """
-    Indicates that one or more receivers of a signal threw when called.
+    Indicates that one or more receivers of a signal raised an exception when called.
     """
 
 


### PR DESCRIPTION
This will aid in error recovery -- if we need to replay a chunk of the
topic, we'll need to have partition and offset information in the logs.
The thrown exception is given its own class in order to help with building
alerts that can discriminate between different sources of errors (business
logic unique to the consuming IDA vs. more generic kafka/avro issues).

This is part of https://github.com/openedx/event-bus-kafka/issues/62

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
- [x] Noted any: Concerns, dependencies, deadlines, tickets, testing instructions
