### PR TITLE
feat: Add the ability to override offsets.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 **********
 
+[3.2.0] - 2022-12-14
+********************
+Changed
+=======
+* Add timestamp parameter for consumer, allowing the starting offset for consuming to be overridden from the default.
+
 [3.1.0] - 2022-12-07
 ********************
 


### PR DESCRIPTION
In the case where we would want to replay events,
we would need to change the offsets in the partitions so that we can consume from an earlier point. This allows users to pass in a new offset parameter that will reset the offsets before starting to consume again.

https://github.com/edx/edx-arch-experiments/issues/115


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
- [x] Noted any: Concerns, dependencies, deadlines, tickets, testing instructions
