### PR TITLE
feat: kill consumer loop on fatal errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 **********
 
+[3.4.0] - 2022-12-16
+********************
+Changed
+=======
+* Kill infinite consumer loop when we see a fatal KafkaError, as recommended in the documentation. See https://github.com/confluentinc/librdkafka/blob/e0b9e92a0b492b5b1a6f1bcf08744928d45bf396/INTRODUCTION.md#fatal-consumer-errors.
+
 [3.3.0] - 2022-12-15
 ********************
 Changed

--- a/edx_event_bus_kafka/__init__.py
+++ b/edx_event_bus_kafka/__init__.py
@@ -9,4 +9,4 @@ See ADR ``docs/decisions/0006-public-api-and-app-organization.rst`` for the reas
 from edx_event_bus_kafka.internal.consumer import KafkaEventConsumer
 from edx_event_bus_kafka.internal.producer import KafkaEventProducer, create_producer
 
-__version__ = '3.3.0'
+__version__ = '3.4.0'

--- a/edx_event_bus_kafka/internal/consumer.py
+++ b/edx_event_bus_kafka/internal/consumer.py
@@ -191,6 +191,10 @@ class KafkaEventConsumer:
                     self._add_message_monitoring(run_context=run_context, message=msg)
                 except Exception as e:  # pylint: disable=broad-except
                     self.record_event_consuming_error(run_context, e, msg)
+                    # Kill the infinite loop if the error is fatal for the consumer
+                    _, kafka_error = self._get_kafka_message_and_error(message=msg, error=e)
+                    if kafka_error and kafka_error.fatal():
+                        raise e
                     # Prevent fast error-looping when no event received from broker. Because
                     # DeserializingConsumer raises rather than returning a Message when it has an
                     # error() value, this may be triggered even when a Message *was* returned,


### PR DESCRIPTION
Kill infinite consumer loop when we see a fatal KafkaError, as recommended in the documentation. See
https://github.com/confluentinc/librdkafka/blob/e0b9e92a0b492b5b1a6f1bcf08744928d45bf396/INTRODUCTION.md#fatal-consumer-errors

Task: https://github.com/edx/edx-arch-experiments/issues/139


**Merge checklist:**
Check off if complete *or* not applicable:
- [X] Version bumped
- [X] Changelog record added
- [X] Documentation updated (not only docstrings)
- [x] Commits are squashed