### PR TITLE
feat: Allow exiting consumer if too many errors in a row

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,10 +13,17 @@ Change Log
 
 Unreleased
 **********
+
+[3.5.0] - 2023-01-05
+********************
+Added
+=====
+* New setting ``EVENT_BUS_KAFKA_CONSUMER_CONSECUTIVE_ERRORS_LIMIT`` will terminate the consumer if too many errors occur in a row, supporting an automated version of "have you tried turning it off and on again" (as long as consumer will automatically be restarted e.g. by Kubernetes).
+
 [3.4.1] - 2022-12-20
 ********************
 Fixed
-=======
+=====
 * Fixed bugs in the event replay/offset handling code for consumers.
 
 [3.4.0] - 2022-12-16

--- a/README.rst
+++ b/README.rst
@@ -29,10 +29,16 @@ Documentation
 
 To use this implementation of the Event Bus with openedx-events, set the following Django settings::
 
-    EVENT_BUS_PRODUCER: edx_event_bus_kafka.create_producer
     EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS: ...
     EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL: ...
     EVENT_BUS_TOPIC_PREFIX: ...
+
+    # Required, on the producing side only:
+    EVENT_BUS_PRODUCER: edx_event_bus_kafka.create_producer
+
+Optional settings that are worth considering:
+
+- ``EVENT_BUS_KAFKA_CONSUMER_CONSECUTIVE_ERRORS_LIMIT``
 
 For manual testing, see `<docs/how_tos/manual_testing.rst>`__.
 

--- a/edx_event_bus_kafka/__init__.py
+++ b/edx_event_bus_kafka/__init__.py
@@ -9,4 +9,4 @@ See ADR ``docs/decisions/0006-public-api-and-app-organization.rst`` for the reas
 from edx_event_bus_kafka.internal.consumer import KafkaEventConsumer
 from edx_event_bus_kafka.internal.producer import KafkaEventProducer, create_producer
 
-__version__ = '3.4.1'
+__version__ = '3.5.0'


### PR DESCRIPTION
This is intended to help with a stuck DB connection issue we observed:
https://github.com/edx/edx-arch-experiments/issues/144

PR is divided into two commits; first commit is a small testing refactor (extraction of a helper).

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
- [x] Noted any: Concerns, dependencies, deadlines, tickets, testing instructions
