### PR TITLE
feat: Do not consume events when in replay mode.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,13 @@ Change Log
 Unreleased
 **********
 
+
+[3.6.0] - 2023-01-06
+********************
+Changed
+=======
+* Consumers do not consume events after resetting offsets.
+
 [3.5.1] - 2023-01-06
 ********************
 Fixed

--- a/edx_event_bus_kafka/__init__.py
+++ b/edx_event_bus_kafka/__init__.py
@@ -9,4 +9,4 @@ See ADR ``docs/decisions/0006-public-api-and-app-organization.rst`` for the reas
 from edx_event_bus_kafka.internal.consumer import KafkaEventConsumer
 from edx_event_bus_kafka.internal.producer import KafkaEventProducer, create_producer
 
-__version__ = '3.5.1'
+__version__ = '3.6.0'

--- a/edx_event_bus_kafka/internal/consumer.py
+++ b/edx_event_bus_kafka/internal/consumer.py
@@ -208,6 +208,14 @@ class KafkaEventConsumer:
                 if self._shut_down_loop:
                     break
 
+                # If offsets are set, do not consume events.
+                if offset_timestamp is not None:
+                    # This log message may be noisy when we are replaying, but hopefully we only see it
+                    # once every 30 seconds.
+                    logger.info("Offsets are being reset. Sleeping instead of consuming events.")
+                    time.sleep(30)
+                    continue
+
                 # Detect probably-broken consumer and exit with error.
                 if CONSECUTIVE_ERRORS_LIMIT and consecutive_errors >= CONSECUTIVE_ERRORS_LIMIT:
                     raise Exception(f"Too many consecutive errors, exiting ({consecutive_errors} in a row)")


### PR DESCRIPTION
We have been seeing strange behavior when trying to reset the offsets in Kafka for replay. This should simplify the behavior of the event bus when we are trying to reset the offsets on the event bus.

https://github.com/openedx/event-bus-kafka/issues/107


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
- [ ] Noted any: Concerns, dependencies, deadlines, tickets, testing instructions
