### PR TITLE
fix: Added poll call to reset-offset code.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,12 @@ Unreleased
 **********
 
 
+[3.6.1] - 2023-01-20
+********************
+Fixed
+=======
+* Added a poll call to force resets to be processed during replay/offset-reset mode.
+
 [3.6.0] - 2023-01-06
 ********************
 Changed

--- a/edx_event_bus_kafka/__init__.py
+++ b/edx_event_bus_kafka/__init__.py
@@ -9,4 +9,4 @@ See ADR ``docs/decisions/0006-public-api-and-app-organization.rst`` for the reas
 from edx_event_bus_kafka.internal.consumer import KafkaEventConsumer
 from edx_event_bus_kafka.internal.producer import KafkaEventProducer, create_producer
 
-__version__ = '3.6.0'
+__version__ = '3.6.1'

--- a/edx_event_bus_kafka/internal/consumer.py
+++ b/edx_event_bus_kafka/internal/consumer.py
@@ -213,6 +213,13 @@ class KafkaEventConsumer:
                     # This log message may be noisy when we are replaying, but hopefully we only see it
                     # once every 30 seconds.
                     logger.info("Offsets are being reset. Sleeping instead of consuming events.")
+
+                    # We are calling poll here because we believe the offsets will not be set
+                    # correctly until poll is called, despite the offsets being reset in a different call.
+                    # Because we are not trying to consume any messages in this mode, we are deliberately calling
+                    # poll without processing the message it returns or commiting the new offset.
+                    self.consumer.poll(timeout=CONSUMER_POLL_TIMEOUT)
+
                     time.sleep(30)
                     continue
 

--- a/edx_event_bus_kafka/internal/consumer.py
+++ b/edx_event_bus_kafka/internal/consumer.py
@@ -216,8 +216,10 @@ class KafkaEventConsumer:
 
                     # We are calling poll here because we believe the offsets will not be set
                     # correctly until poll is called, despite the offsets being reset in a different call.
-                    # Because we are not trying to consume any messages in this mode, we are deliberately calling
-                    # poll without processing the message it returns or commiting the new offset.
+                    # This is because we don't believe that the partitions for the current consumer are assigned
+                    # until the first poll happens. Because we are not trying to consume any messages in this mode,
+                    # we are deliberately calling poll without processing the message it returns
+                    # or commiting the new offset.
                     self.consumer.poll(timeout=CONSUMER_POLL_TIMEOUT)
 
                     time.sleep(30)


### PR DESCRIPTION
We believe that the offsets are not reset and assigned until poll is called. This poll should not process events or commit the offsets with the messages it returns.


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] Noted any: Concerns, dependencies, deadlines, tickets, testing instructions
