### PR TITLE
fix: Log helpful error if confluent_kafka is not installed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 **********
 
+[3.7.1] - 2023-01-31
+********************
+Fixed
+=====
+* Consumer management command exits with useful error message if confluent-kafka library not available.
+
 [3.7.0] - 2023-01-30
 ********************
 Changed

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ The repository works together with the openedx/openedx-events repository to make
 Documentation
 *************
 
-To use this implementation of the Event Bus with openedx-events, set the following Django settings::
+To use this implementation of the Event Bus with openedx-events, you'll need to ensure that you include the dependency ``confluent_kafka[avro,schema-registry]`` (see `ADR 5 <https://github.com/openedx/event-bus-kafka/blob/main/docs/decisions/0005-optional-import-of-confluent-kafka.rst>`_ for an explanation) and set the following Django settings::
 
     EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS: ...
     EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL: ...

--- a/edx_event_bus_kafka/__init__.py
+++ b/edx_event_bus_kafka/__init__.py
@@ -9,4 +9,4 @@ See ADR ``docs/decisions/0006-public-api-and-app-organization.rst`` for the reas
 from edx_event_bus_kafka.internal.consumer import KafkaEventConsumer
 from edx_event_bus_kafka.internal.producer import KafkaEventProducer, create_producer
 
-__version__ = '3.7.0'
+__version__ = '3.7.1'

--- a/edx_event_bus_kafka/internal/consumer.py
+++ b/edx_event_bus_kafka/internal/consumer.py
@@ -557,9 +557,16 @@ class ConsumeEventsCommand(BaseCommand):
         )
 
     def handle(self, *args, **options):
+        if confluent_kafka is None:
+            logger.error(
+                "Cannot consume events because confluent_kafka dependency (or one of its extras) was not installed"
+            )
+            return
+
         if not KAFKA_CONSUMERS_ENABLED.is_enabled():
             logger.error("Kafka consumers not enabled, exiting.")
             return
+
         try:
             signal = OpenEdxPublicSignal.get_signal_by_type(options['signal'][0])
             if options['offset_time'] and options['offset_time'][0] is not None:

--- a/edx_event_bus_kafka/internal/tests/test_consumer.py
+++ b/edx_event_bus_kafka/internal/tests/test_consumer.py
@@ -605,6 +605,16 @@ class TestCommand(TestCase):
         assert not mock_create_consumer.called
         mock_logger.error.assert_called_once_with("Kafka consumers not enabled, exiting.")
 
+    @patch.dict('edx_event_bus_kafka.internal.consumer.__dict__', {'confluent_kafka': None})
+    @patch('edx_event_bus_kafka.internal.consumer.logger', autospec=True)
+    @patch('edx_event_bus_kafka.internal.consumer.KafkaEventConsumer._create_consumer')
+    def test_kafka_consumers_no_lib(self, mock_create_consumer, mock_logger):
+        call_command(Command(), topic='test', group_id='test', signal='')
+        assert not mock_create_consumer.called
+        mock_logger.error.assert_called_once_with(
+            "Cannot consume events because confluent_kafka dependency (or one of its extras) was not installed"
+        )
+
     @patch('edx_event_bus_kafka.internal.consumer.OpenEdxPublicSignal.get_signal_by_type')
     @patch('edx_event_bus_kafka.internal.consumer.KafkaEventConsumer._create_consumer')
     @patch('edx_event_bus_kafka.internal.consumer.KafkaEventConsumer.consume_indefinitely')


### PR DESCRIPTION
Also note the "manual" dependency issue in the README.

This check is already present in course-discovery's copy of the command.

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
- [x] Noted any: Concerns, dependencies, deadlines, tickets, testing instructions
