### PR TITLE
feat: emit original headers with message

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 **********
 
+[3.7.1] - 2023-01-31
+********************
+Fixed
+=====
+* Consumer management command exits with useful error message if confluent-kafka library not available.
+
 [3.7.0] - 2023-01-30
 ********************
 Changed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,13 @@ Change Log
 Unreleased
 **********
 
+[3.8.0] - 2023-01-31
+********************
+Added
+=====
+* Producer now passes all metadata fields as headers
+* Consumer emits events with the original metadata information (from the producer)
+
 [3.7.1] - 2023-01-31
 ********************
 Fixed

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ The repository works together with the openedx/openedx-events repository to make
 Documentation
 *************
 
-To use this implementation of the Event Bus with openedx-events, set the following Django settings::
+To use this implementation of the Event Bus with openedx-events, you'll need to ensure that you include the dependency ``confluent_kafka[avro,schema-registry]`` (see `ADR 5 <https://github.com/openedx/event-bus-kafka/blob/main/docs/decisions/0005-optional-import-of-confluent-kafka.rst>`_ for an explanation) and set the following Django settings::
 
     EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS: ...
     EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL: ...

--- a/edx_event_bus_kafka/__init__.py
+++ b/edx_event_bus_kafka/__init__.py
@@ -9,4 +9,4 @@ See ADR ``docs/decisions/0006-public-api-and-app-organization.rst`` for the reas
 from edx_event_bus_kafka.internal.consumer import KafkaEventConsumer
 from edx_event_bus_kafka.internal.producer import KafkaEventProducer, create_producer
 
-__version__ = '3.7.1'
+__version__ = '3.8.0'

--- a/edx_event_bus_kafka/__init__.py
+++ b/edx_event_bus_kafka/__init__.py
@@ -9,4 +9,4 @@ See ADR ``docs/decisions/0006-public-api-and-app-organization.rst`` for the reas
 from edx_event_bus_kafka.internal.consumer import KafkaEventConsumer
 from edx_event_bus_kafka.internal.producer import KafkaEventProducer, create_producer
 
-__version__ = '3.7.0'
+__version__ = '3.7.1'

--- a/edx_event_bus_kafka/internal/consumer.py
+++ b/edx_event_bus_kafka/internal/consumer.py
@@ -356,7 +356,7 @@ class KafkaEventConsumer:
                                     # and will raise if it's present
                                     filter=filters.exclude(fields(EventsMetadata).event_type))
         except Exception as e:
-            raise UnusableMessageError(f"Error determining metadata from message headers: {e}")
+            raise UnusableMessageError(f"Error determining metadata from message headers: {e}") from e
         send_results = self.signal.send_event_with_custom_metadata(**event_metadata, **msg.value())
         # Raise an exception if any receivers errored out. This allows logging of the receivers
         # along with partition, offset, etc. in record_event_consuming_error. Hopefully the

--- a/edx_event_bus_kafka/internal/consumer.py
+++ b/edx_event_bus_kafka/internal/consumer.py
@@ -557,9 +557,16 @@ class ConsumeEventsCommand(BaseCommand):
         )
 
     def handle(self, *args, **options):
+        if confluent_kafka is None:
+            logger.error(
+                "Cannot consume events because confluent_kafka dependency (or one of its extras) was not installed"
+            )
+            return
+
         if not KAFKA_CONSUMERS_ENABLED.is_enabled():
             logger.error("Kafka consumers not enabled, exiting.")
             return
+
         try:
             signal = OpenEdxPublicSignal.get_signal_by_type(options['signal'][0])
             if options['offset_time'] and options['offset_time'][0] is not None:

--- a/edx_event_bus_kafka/internal/tests/test_consumer.py
+++ b/edx_event_bus_kafka/internal/tests/test_consumer.py
@@ -599,13 +599,12 @@ class TestEmitSignals(TestCase):
 
         The various kinds of bad headers are more fully tested in test_utils
         """
-        msg = copy.copy(self.normal_message)
-        msg._headers = [  # pylint: disable=protected-access
+        self.normal_message._headers = [  # pylint: disable=protected-access
             ('ce_type', b'org.openedx.learning.auth.session.login.completed.v1'),
             ('ce_id', b'bad_id')
         ]
         with pytest.raises(UnusableMessageError) as excinfo:
-            self.event_consumer.emit_signals_from_message(msg)
+            self.event_consumer.emit_signals_from_message(self.normal_message)
 
         assert excinfo.value.args == (
             "Error determining metadata from message headers: badly formed hexadecimal UUID string",

--- a/edx_event_bus_kafka/internal/tests/test_consumer.py
+++ b/edx_event_bus_kafka/internal/tests/test_consumer.py
@@ -5,7 +5,7 @@ Tests for event_consumer module.
 import copy
 from datetime import datetime
 from typing import Optional
-from unittest.mock import ANY, Mock, call, patch
+from unittest.mock import Mock, call, patch
 from uuid import uuid1
 
 import ddt

--- a/edx_event_bus_kafka/internal/tests/test_consumer.py
+++ b/edx_event_bus_kafka/internal/tests/test_consumer.py
@@ -605,6 +605,16 @@ class TestCommand(TestCase):
         assert not mock_create_consumer.called
         mock_logger.error.assert_called_once_with("Kafka consumers not enabled, exiting.")
 
+    @patch.dict('edx_event_bus_kafka.internal.consumer.__dict__', {'confluent_kafka': None})
+    @patch('edx_event_bus_kafka.internal.consumer.logger', autospec=True)
+    @patch('edx_event_bus_kafka.internal.consumer.KafkaEventConsumer._create_consumer')
+    def test_kafka_consumers_no_lib(self, mock_create_consumer, mock_logger):
+        call_command(Command(), topic='test', group_id='test', signal='')
+        assert not mock_create_consumer.called
+        mock_logger.error.assert_called_once_with(
+            "Cannot consume events because confluent_kafka dependency (or one of its extras) was not installed"
+        )
+
     @patch('edx_event_bus_kafka.internal.consumer.OpenEdxPublicSignal.get_signal_by_type')
     @patch('edx_event_bus_kafka.internal.consumer.KafkaEventConsumer._create_consumer')
     @patch('edx_event_bus_kafka.internal.consumer.KafkaEventConsumer.consume_indefinitely')

--- a/edx_event_bus_kafka/internal/tests/test_utils.py
+++ b/edx_event_bus_kafka/internal/tests/test_utils.py
@@ -12,10 +12,10 @@ from django.test import TestCase, override_settings
 from openedx_events.data import EventsMetadata
 
 from edx_event_bus_kafka.internal.utils import (
-    EVENT_TYPE_HEADER_KEY,
-    ID_HEADER_KEY,
-    SOURCELIB_HEADER_KEY,
-    TIME_HEADER_KEY,
+    HEADER_EVENT_TYPE,
+    HEADER_ID,
+    HEADER_SOURCELIB,
+    HEADER_TIME,
     _get_headers_from_metadata,
     _get_metadata_from_headers,
 )
@@ -66,7 +66,8 @@ class TestUtils(TestCase):
             ('content-type', b'application/avro'),
             ('ce_datacontenttype', b'application/avro'),
             ('ce_time', b'2023-01-01T14:00:00+00:00'),
-            ('sourcelib', b'1.2.3')
+            ('sourcelib', b'1.2.3'),
+            ('minorversion', b'0')
         ]
         generated_metadata = _get_metadata_from_headers(headers)
         expected_metadata = EventsMetadata(
@@ -98,10 +99,10 @@ class TestUtils(TestCase):
         now = datetime.now(timezone.utc)
         mock_dt.now = Mock(return_value=now)
         headers = filter(lambda x: x[1] is not None, [
-            (ID_HEADER_KEY, msg_id),
-            (TIME_HEADER_KEY, msg_time),
-            (SOURCELIB_HEADER_KEY, source_lib),
-            (EVENT_TYPE_HEADER_KEY, b'abc')
+            (HEADER_ID.message_header_key, msg_id),
+            (HEADER_TIME.message_header_key, msg_time),
+            (HEADER_SOURCELIB.message_header_key, source_lib),
+            (HEADER_EVENT_TYPE.message_header_key, b'abc')
         ])
         if should_raise:
             with pytest.raises(Exception):
@@ -118,9 +119,9 @@ class TestUtils(TestCase):
         Check that we raise if there are duplicate headers
         """
         headers = [
-            (ID_HEADER_KEY, str(TEST_UUID).encode("utf-8")),
-            (ID_HEADER_KEY, str(uuid1()).encode("utf-8")),
-            (EVENT_TYPE_HEADER_KEY, b'abc')
+            (HEADER_ID.message_header_key, str(TEST_UUID).encode("utf-8")),
+            (HEADER_ID.message_header_key, str(uuid1()).encode("utf-8")),
+            (HEADER_EVENT_TYPE.message_header_key, b'abc')
         ]
         with pytest.raises(Exception) as exc_info:
             _get_metadata_from_headers(headers)

--- a/edx_event_bus_kafka/internal/tests/test_utils.py
+++ b/edx_event_bus_kafka/internal/tests/test_utils.py
@@ -8,16 +8,12 @@ from uuid import uuid1
 import attr
 import ddt
 import pytest
-from attrs import asdict, fields, filters
 from django.test import TestCase, override_settings
 from openedx_events.data import EventsMetadata
 
 from edx_event_bus_kafka.internal.utils import (
     EVENT_TYPE_HEADER_KEY,
     ID_HEADER_KEY,
-    MINORVERSION_HEADER_KEY,
-    SOURCE_HEADER_KEY,
-    SOURCEHOST_HEADER_KEY,
     SOURCELIB_HEADER_KEY,
     TIME_HEADER_KEY,
     _get_headers_from_metadata,

--- a/edx_event_bus_kafka/internal/tests/test_utils.py
+++ b/edx_event_bus_kafka/internal/tests/test_utils.py
@@ -1,0 +1,109 @@
+"""
+Test header conversion utils
+"""
+from datetime import datetime, timezone
+from unittest.mock import Mock, patch
+from uuid import uuid1
+
+import attr
+import ddt
+import pytest
+from attrs import asdict, fields, filters
+from django.test import TestCase, override_settings
+from openedx_events.data import EventsMetadata
+
+from edx_event_bus_kafka.internal.utils import (
+    EVENT_TYPE_HEADER_KEY,
+    ID_HEADER_KEY,
+    MINORVERSION_HEADER_KEY,
+    SOURCE_HEADER_KEY,
+    SOURCEHOST_HEADER_KEY,
+    SOURCELIB_HEADER_KEY,
+    TIME_HEADER_KEY,
+    _get_headers_from_metadata,
+    _get_metadata_from_headers,
+)
+
+TEST_UUID = uuid1()
+
+
+@ddt.ddt
+class TestUtils(TestCase):
+    """ Tests for header conversion utils """
+
+    def test_headers_from_event_metadata(self):
+        with override_settings(SERVICE_VARIANT='test'):
+            metadata = EventsMetadata(event_type="org.openedx.learning.auth.session.login.completed.v1",
+                                      id=TEST_UUID,
+                                      sourcelib=(1, 2, 3),
+                                      sourcehost="host",
+                                      minorversion=0,
+                                      time=datetime.fromisoformat("2023-01-01T14:00:00+00:00"))
+            headers = _get_headers_from_metadata(event_metadata=metadata)
+            self.assertDictEqual(headers, {
+                'ce_type': b'org.openedx.learning.auth.session.login.completed.v1',
+                'ce_id': str(TEST_UUID).encode("utf8"),
+                'ce_source': b'openedx/test/web',
+                'ce_specversion': b'1.0',
+                'sourcehost': b'host',
+                'content-type': b'application/avro',
+                'ce_datacontenttype': b'application/avro',
+                'ce_time': b'2023-01-01T14:00:00+00:00',
+                'sourcelib': b'1.2.3',
+                'ce_minorversion': b'0',
+            })
+
+    def test_metadata_from_headers(self):
+        uuid = uuid1()
+        headers = [
+            ('ce_type', b'org.openedx.learning.auth.session.login.completed.v1'),
+            ('ce_id', str(uuid).encode("utf8")),
+            ('ce_source', b'openedx/test/web'),
+            ('ce_specversion', b'1.0'),
+            ('sourcehost', b'testsource'),
+            ('content-type', b'application/avro'),
+            ('ce_datacontenttype', b'application/avro'),
+            ('ce_time', b'2023-01-01T14:00:00+00:00'),
+            ('sourcelib', b'1.2.3')
+        ]
+        generated_metadata = _get_metadata_from_headers(headers)
+        expected_metadata = EventsMetadata(
+            event_type="org.openedx.learning.auth.session.login.completed.v1",
+            id=uuid,
+            minorversion=0,
+            source='openedx/test/web',
+            sourcehost='testsource',
+            time=datetime.fromisoformat("2023-01-01T14:00:00+00:00"),
+            sourcelib=(1, 2, 3),
+        )
+        self.assertDictEqual(attr.asdict(generated_metadata), attr.asdict(expected_metadata))
+
+    TEST_UUID_BYTES = str(TEST_UUID).encode("utf8")
+
+    @patch('edx_event_bus_kafka.internal.utils.oed.datetime')
+    @ddt.data(
+        (TEST_UUID_BYTES, None, None, False),
+        (b'bad-id', None, None, True),
+        (TEST_UUID_BYTES, b'0000', None, True),
+        (TEST_UUID_BYTES, None, b'bananas', True),
+        (None, None, None, True),
+    )
+    @ddt.unpack
+    def test_metadata_from_missing_or_bad_headers(self, msg_id, msg_time, source_lib, should_raise, mock_dt):
+        now = datetime.now(timezone.utc)
+        mock_dt.now = Mock(return_value=now)
+        headers = filter(lambda x: x[1] is not None, [
+            (ID_HEADER_KEY, msg_id),
+            (TIME_HEADER_KEY, msg_time),
+            (SOURCELIB_HEADER_KEY, source_lib),
+            (EVENT_TYPE_HEADER_KEY, b'abc')
+        ])
+        if should_raise:
+            with pytest.raises(Exception):
+                _get_metadata_from_headers(headers)
+        else:
+            # check that we use all the regular EventsMetadata defaults for missing fields by constructing one
+            # and comparing it to the one generated from _get_metadata_from_headers
+            expected_metadata = EventsMetadata(event_type="abc", id=TEST_UUID)
+            generated_metadata = _get_metadata_from_headers(headers)
+            self.assertDictEqual(attr.asdict(generated_metadata), attr.asdict(expected_metadata))

--- a/edx_event_bus_kafka/internal/utils.py
+++ b/edx_event_bus_kafka/internal/utils.py
@@ -3,7 +3,6 @@ Utilities for converting between message headers and EventsMetadata
 """
 
 import logging
-import re
 from collections import defaultdict
 from datetime import datetime
 from typing import List, Tuple
@@ -41,8 +40,10 @@ HEADER_KEY_TO_EVENTSMETADATA_FIELD = {
     SOURCELIB_HEADER_KEY: 'sourcelib'
 }
 
+
 def _sourcelib_tuple_to_str(sourcelib: Tuple):
-    return ".".join(map(str,sourcelib))
+    return ".".join(map(str, sourcelib))
+
 
 def _sourcelib_str_to_tuple(sourcelib_as_str: str):
     return tuple(map(int, sourcelib_as_str.split(".")))
@@ -72,11 +73,11 @@ def _get_metadata_from_headers(headers: List[Tuple]):
         if len(header_values) == 0:
             # the id is required, everything else we make optional for now
             if header_key == ID_HEADER_KEY:
-                raise UnusableMessageError(f"Missing \"{header_key}\" header on message, cannot continue")
+                raise Exception(f"Missing \"{header_key}\" header on message, cannot continue")
             logger.warning(f"Missing \"{header_key}\" header on message, will use EventMetadata default")
             continue
         if len(header_values) > 1:
-            raise UnusableMessageError(
+            raise Exception(
                 f"Multiple \"{header_key}\" headers on message. Cannot determine correct metadata."
             )
         header_value = header_values[0].decode("utf-8")

--- a/edx_event_bus_kafka/internal/utils.py
+++ b/edx_event_bus_kafka/internal/utils.py
@@ -87,7 +87,7 @@ def _get_metadata_from_headers(headers: List[Tuple]):
             # the id is required, everything else we make optional for now
             if header_key == HEADER_ID.message_header_key:
                 raise Exception(f"Missing \"{header_key}\" header on message, cannot continue")
-            logger.warning(f"Missing \"{header_key}\" header on message, will use EventMetadata default")
+            logger.warning(f"Missing \"{header_key}\" header on message, will use EventsMetadata default")
             continue
         if len(header_values) > 1:
             raise Exception(
@@ -102,16 +102,14 @@ def _get_headers_from_metadata(event_metadata: oed.EventsMetadata):
     """
     Create a dictionary of CloudEvent-compliant Kafka headers from an EventsMetadata object.
 
-    This method assumes the EventMetadata object was the one sent with the event data to the original signal handler.
+    This method assumes the EventsMetadata object was the one sent with the event data to the original signal handler.
 
     Arguments:
         event_metadata: An EventsMetadata object sent by an OpenEdxPublicSignal
 
     Returns:
-        A dictionary of headers
+        A dictionary of headers where the keys are strings and values are binary
     """
-    # Dictionary (or list of key/value tuples) where keys are strings and values are binary.
-    # CloudEvents specifies using UTF-8; that should be the default, but let's make it explicit.
     values = {
         # Always 1.0. See "Fields" in OEP-41
         HEADER_SPEC_VERSION.message_header_key: b'1.0',
@@ -122,6 +120,7 @@ def _get_headers_from_metadata(event_metadata: oed.EventsMetadata):
         if not header.event_metadata_field:
             continue
         event_metadata_value = getattr(event_metadata, header.event_metadata_field)
+        # CloudEvents specifies using UTF-8; that should be the default, but let's make it explicit.
         values[header.message_header_key] = header.from_metadata(event_metadata_value).encode("utf8")
 
     return values

--- a/edx_event_bus_kafka/internal/utils.py
+++ b/edx_event_bus_kafka/internal/utils.py
@@ -22,6 +22,9 @@ def _sourcelib_str_to_tuple(sourcelib_as_str: str):
 
 
 class MessageHeader:
+    """
+    Utility class for converting between message headers and EventsMetadata objects
+    """
     _mapping = {}
     instances = []
 
@@ -39,7 +42,8 @@ HEADER_ID = MessageHeader("ce_id", event_metadata_field="id", from_metadata=str,
 HEADER_SOURCE = MessageHeader("ce_source", event_metadata_field="source")
 HEADER_SPEC_VERSION = MessageHeader("ce_specversion")
 HEADER_TIME = MessageHeader("ce_time", event_metadata_field="time",
-                            to_metadata=lambda x: datetime.fromisoformat(x), from_metadata=lambda x: x.isoformat())
+                            to_metadata=lambda x: datetime.fromisoformat(x),  # pylint: disable=unnecessary-lambda
+                            from_metadata=lambda x: x.isoformat())
 HEADER_MINORVERSION = MessageHeader("ce_minorversion", event_metadata_field="minorversion", to_metadata=int,
                                     from_metadata=str)
 
@@ -117,6 +121,7 @@ def _get_headers_from_metadata(event_metadata: oed.EventsMetadata):
     for header in MessageHeader.instances:
         if not header.event_metadata_field:
             continue
-        values[header.message_header_key] = header.from_metadata(getattr(event_metadata, header.event_metadata_field)).encode("utf8")
+        event_metadata_value = getattr(event_metadata, header.event_metadata_field)
+        values[header.message_header_key] = header.from_metadata(event_metadata_value).encode("utf8")
 
     return values

--- a/edx_event_bus_kafka/internal/utils.py
+++ b/edx_event_bus_kafka/internal/utils.py
@@ -1,0 +1,125 @@
+"""
+Utilities for converting between message headers and EventsMetadata
+"""
+
+import logging
+import re
+from collections import defaultdict
+from datetime import datetime
+from typing import List, Tuple
+from uuid import UUID
+
+import openedx_events.data as oed
+
+EVENT_TYPE_HEADER_KEY = "ce_type"
+ID_HEADER_KEY = "ce_id"
+SOURCE_HEADER_KEY = "ce_source"
+SPEC_VERSION_HEADER_KEY = "ce_specversion"
+TIME_HEADER_KEY = "ce_time"
+MINORVERSION_HEADER_KEY = "ce_minorversion"
+
+# not CloudEvent headers, so no "ce" prefix
+SOURCEHOST_HEADER_KEY = "sourcehost"
+SOURCELIB_HEADER_KEY = "sourcelib"
+
+# The documentation is unclear as to which of the following two headers to use for content type, so for now
+# use both
+CONTENT_TYPE_HEADER_KEY = "content-type"
+DATA_CONTENT_TYPE_HEADER_KEY = "ce_datacontenttype"
+
+logger = logging.getLogger(__name__)
+
+# We don't use the ce_type header when creating the EventsMetadata object because that is dealt with separately in the
+# consumer loop
+HEADER_KEY_TO_EVENTSMETADATA_FIELD = {
+    EVENT_TYPE_HEADER_KEY: 'event_type',
+    ID_HEADER_KEY: 'id',
+    MINORVERSION_HEADER_KEY: 'minorversion',
+    SOURCE_HEADER_KEY: 'source',
+    SOURCEHOST_HEADER_KEY: 'sourcehost',
+    TIME_HEADER_KEY: 'time',
+    SOURCELIB_HEADER_KEY: 'sourcelib'
+}
+
+def _sourcelib_tuple_to_str(sourcelib: Tuple):
+    return ".".join(map(str,sourcelib))
+
+def _sourcelib_str_to_tuple(sourcelib_as_str: str):
+    return tuple(map(int, sourcelib_as_str.split(".")))
+
+
+def _get_metadata_from_headers(headers: List[Tuple]):
+    """
+    Create an EventsMetadata object from the headers of a Kafka message
+
+    Arguments
+        headers: The list of headers returned from calling message.headers() on a consumed message
+
+    Returns
+        An instance of EventsMetadata with the parameters from the headers. Any fields missing from the headers
+         are set to the defaults of the EventsMetadata class
+    """
+    # Transform list of (header, value) tuples to a {header: [list of values]} dict. Necessary as an intermediate
+    # step because there is no guarantee of unique headers in the list of tuples
+    headers_as_dict = defaultdict(list)
+    metadata_kwargs = {}
+    for key, value in headers:
+        headers_as_dict[key].append(value)
+
+    # go through all the headers we care about and set the appropriate field
+    for header_key, metadata_field in HEADER_KEY_TO_EVENTSMETADATA_FIELD.items():
+        header_values = headers_as_dict[header_key]
+        if len(header_values) == 0:
+            # the id is required, everything else we make optional for now
+            if header_key == ID_HEADER_KEY:
+                raise UnusableMessageError(f"Missing \"{header_key}\" header on message, cannot continue")
+            logger.warning(f"Missing \"{header_key}\" header on message, will use EventMetadata default")
+            continue
+        if len(header_values) > 1:
+            raise UnusableMessageError(
+                f"Multiple \"{header_key}\" headers on message. Cannot determine correct metadata."
+            )
+        header_value = header_values[0].decode("utf-8")
+        # some headers require conversion to the expected type
+        if header_key == ID_HEADER_KEY:
+            metadata_kwargs[metadata_field] = UUID(header_value)
+        elif header_key == TIME_HEADER_KEY:
+            metadata_kwargs[metadata_field] = datetime.fromisoformat(header_value)
+        elif header_key == SOURCELIB_HEADER_KEY:
+            metadata_kwargs[metadata_field] = _sourcelib_str_to_tuple(header_value)
+        else:
+            # these are all string values and don't need any conversion step
+            metadata_kwargs[metadata_field] = header_value
+    return oed.EventsMetadata(**metadata_kwargs)
+
+
+def _get_headers_from_metadata(event_metadata: oed.EventsMetadata):
+    """
+    Create a dictionary of CloudEvent-compliant Kafka headers from an EventsMetadata object.
+
+    This method assumes the EventMetadata object was the one sent with the event data to the original signal handler.
+
+    Arguments:
+        event_metadata: An EventsMetadata object sent by an OpenEdxPublicSignal
+
+    Returns:
+        A dictionary of headers
+    """
+    # Dictionary (or list of key/value tuples) where keys are strings and values are binary.
+    # CloudEvents specifies using UTF-8; that should be the default, but let's make it explicit.
+    return {
+        # The way EventMetadata is initialized none of these should ever be null.
+        # If it is we want the error to be raised.
+        EVENT_TYPE_HEADER_KEY: event_metadata.event_type.encode("utf-8"),
+        ID_HEADER_KEY: str(event_metadata.id).encode("utf-8"),
+        SOURCE_HEADER_KEY: event_metadata.source.encode("utf-8"),
+        SOURCEHOST_HEADER_KEY: event_metadata.sourcehost.encode("utf-8"),
+        TIME_HEADER_KEY: event_metadata.time.isoformat().encode("utf-8"),
+        MINORVERSION_HEADER_KEY: str(event_metadata.minorversion).encode("utf-8"),
+        SOURCELIB_HEADER_KEY: _sourcelib_tuple_to_str(event_metadata.sourcelib).encode("utf-8"),
+
+        # Always 1.0. See "Fields" in OEP-41
+        SPEC_VERSION_HEADER_KEY: b'1.0',
+        CONTENT_TYPE_HEADER_KEY: b'application/avro',
+        DATA_CONTENT_TYPE_HEADER_KEY: b'application/avro',
+    }

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,6 +3,6 @@
 
 Django                                  # Web application framework
 # openedx-events 3.1.0 defines producer interface
-openedx-events>=4.2.0                   # Events API
+openedx-events>=4.2.0                   # EventsMetadata default fields
 edx_django_utils
 edx_toggles

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,7 +2,7 @@
 -c constraints.txt
 
 Django                                  # Web application framework
-# openedx-events 3.1.0 defines producer interface
-openedx-events>=4.2.0                   # EventsMetadata default fields
+# openedx-events 4.2.0 allows sending signals with custom metadata
+openedx-events>=4.2.0                   # Events API
 edx_django_utils
 edx_toggles

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,6 +3,6 @@
 
 Django                                  # Web application framework
 # openedx-events 3.1.0 defines producer interface
-openedx-events>=3.1.0                   # Events API
+openedx-events>=4.2.0                   # Events API
 edx_django_utils
 edx_toggles


### PR DESCRIPTION
Issue: https://github.com/openedx/openedx-events/issues/162

Pass all EventsMetadata fields as headers when producing an event to Kafka. The consumer takes these headers and emits the signal with the original metadata, as reconstructed from the message headers.

To prevent the need for lock-step upgrades, all headers except event type and id are considered optional. If not passed, we will just use the default value in EventsMetadata. This is why _get_metadata_from_headers returns and EventsMetadata object instead of just a dictionary of kwargs to pass to `send_event_with_custom_metadata`. 
We can make another ticket to make the other headers mandatory after and possibly rethink what _get_metadata_from_headers returns. 

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] Noted any: Concerns, dependencies, deadlines, tickets, testing instructions
