### PR TITLE
fix: Use openedx-events 5.0.0 and new custom-metadata method signature

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 **********
 
+[3.8.1] - 2023-02-03
+********************
+Changed
+=======
+* Require and use openedx-events 5.0.0, which has a breaking API change that affects event bus consumers.
+
 [3.8.0] - 2023-01-31
 ********************
 Added

--- a/edx_event_bus_kafka/__init__.py
+++ b/edx_event_bus_kafka/__init__.py
@@ -9,4 +9,4 @@ See ADR ``docs/decisions/0006-public-api-and-app-organization.rst`` for the reas
 from edx_event_bus_kafka.internal.consumer import KafkaEventConsumer
 from edx_event_bus_kafka.internal.producer import KafkaEventProducer, create_producer
 
-__version__ = '3.8.0'
+__version__ = '3.8.1'

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,6 +3,7 @@
 
 Django                                  # Web application framework
 # openedx-events 5.0.0 has a breaking API change that requires code changes in this library
-openedx-events>=5.0.0                   # Events API
+#openedx-events>=5.0.0                   # Events API
+git+https://github.com/openedx/openedx-events.git@timmc/custom2#egg=openedx-events==5.0.0
 edx_django_utils
 edx_toggles

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,7 +3,6 @@
 
 Django                                  # Web application framework
 # openedx-events 5.0.0 has a breaking API change that requires code changes in this library
-#openedx-events>=5.0.0                   # Events API
-git+https://github.com/openedx/openedx-events.git@timmc/custom2#egg=openedx-events==5.0.0
+openedx-events>=5.0.0                   # Events API
 edx_django_utils
 edx_toggles

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,7 +2,7 @@
 -c constraints.txt
 
 Django                                  # Web application framework
-# openedx-events 4.2.0 allows sending signals with custom metadata
-openedx-events>=4.2.0                   # Events API
+# openedx-events 5.0.0 has a breaking API change that requires code changes in this library
+openedx-events>=5.0.0                   # Events API
 edx_django_utils
 edx_toggles

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -48,7 +48,7 @@ markupsafe==2.1.2
     # via jinja2
 newrelic==8.5.0
     # via edx-django-utils
-openedx-events @ git+https://github.com/openedx/openedx-events.git@timmc/custom2
+openedx-events==5.0.0
     # via -r requirements/base.in
 pbr==5.11.1
     # via stevedore

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -48,7 +48,7 @@ markupsafe==2.1.2
     # via jinja2
 newrelic==8.5.0
     # via edx-django-utils
-openedx-events==4.2.0
+openedx-events @ git+https://github.com/openedx/openedx-events.git@timmc/custom2
     # via -r requirements/base.in
 pbr==5.11.1
     # via stevedore

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -210,7 +210,7 @@ newrelic==8.5.0
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
-openedx-events @ git+https://github.com/openedx/openedx-events.git@timmc/custom2
+openedx-events==5.0.0
     # via -r requirements/quality.txt
 packaging==23.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -210,7 +210,7 @@ newrelic==8.5.0
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
-openedx-events==4.2.0
+openedx-events @ git+https://github.com/openedx/openedx-events.git@timmc/custom2
     # via -r requirements/quality.txt
 packaging==23.0
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -148,7 +148,7 @@ newrelic==8.5.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-openedx-events @ git+https://github.com/openedx/openedx-events.git@timmc/custom2
+openedx-events==5.0.0
     # via -r requirements/test.txt
 packaging==23.0
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -148,7 +148,7 @@ newrelic==8.5.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-openedx-events==4.2.0
+openedx-events @ git+https://github.com/openedx/openedx-events.git@timmc/custom2
     # via -r requirements/test.txt
 packaging==23.0
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -151,7 +151,7 @@ newrelic==8.5.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-openedx-events==4.2.0
+openedx-events @ git+https://github.com/openedx/openedx-events.git@timmc/custom2
     # via -r requirements/test.txt
 packaging==23.0
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -151,7 +151,7 @@ newrelic==8.5.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-openedx-events @ git+https://github.com/openedx/openedx-events.git@timmc/custom2
+openedx-events==5.0.0
     # via -r requirements/test.txt
 packaging==23.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -89,7 +89,7 @@ newrelic==8.5.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-openedx-events==4.2.0
+openedx-events @ git+https://github.com/openedx/openedx-events.git@timmc/custom2
     # via -r requirements/base.txt
 packaging==23.0
     # via pytest

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -89,7 +89,7 @@ newrelic==8.5.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-openedx-events @ git+https://github.com/openedx/openedx-events.git@timmc/custom2
+openedx-events==5.0.0
     # via -r requirements/base.txt
 packaging==23.0
     # via pytest


### PR DESCRIPTION
This just follows a breaking API change in openedx-events and should not have any impact on dependents.

Pending:

- [x] `make upgrade` with new openedx-events version, once https://github.com/openedx/openedx-events/pull/179 is merged and released.

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
- [x] Noted any: Concerns, dependencies, deadlines, tickets, testing instructions
