### PR TITLE
fix: Include message_id correctly in producer audit log

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,13 @@ Change Log
 Unreleased
 **********
 
-[3.9.2] - 2023-02-07
+[3.9.3] - 2023-02-10
+********************
+Fixed
+=====
+* Include ``message_id`` in audit log when message is produced (was ``None``)
+
+[3.9.2] - 2023-02-08
 ********************
 Fixed
 =====

--- a/edx_event_bus_kafka/__init__.py
+++ b/edx_event_bus_kafka/__init__.py
@@ -9,4 +9,4 @@ See ADR ``docs/decisions/0006-public-api-and-app-organization.rst`` for the reas
 from edx_event_bus_kafka.internal.consumer import KafkaEventConsumer
 from edx_event_bus_kafka.internal.producer import KafkaEventProducer, create_producer
 
-__version__ = '3.9.2'
+__version__ = '3.9.3'

--- a/edx_event_bus_kafka/internal/producer.py
+++ b/edx_event_bus_kafka/internal/producer.py
@@ -23,7 +23,7 @@ from openedx_events.event_bus.avro.serializer import AvroSignalSerializer
 from openedx_events.tooling import OpenEdxPublicSignal
 
 from .config import get_full_topic, get_schema_registry_client, load_common_settings
-from .utils import AUDIT_LOGGING_ENABLED, HEADER_ID, _get_headers_from_metadata, last_message_header_value
+from .utils import AUDIT_LOGGING_ENABLED, _get_headers_from_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -211,7 +211,9 @@ class ProducingContext:
             if not AUDIT_LOGGING_ENABLED.is_enabled():
                 return
 
-            message_id = last_message_header_value(evt.headers() or [], HEADER_ID)
+            # `evt.headers()` is None in this callback, so we need to use the bound data.
+            # https://github.com/confluentinc/confluent-kafka-python/issues/574
+            message_id = self.event_metadata.id
             # See ADR for details on why certain fields were included or omitted.
             logger.info(
                 f"Message delivered to Kafka event bus: topic={evt.topic()}, partition={evt.partition()}, "

--- a/edx_event_bus_kafka/internal/tests/test_consumer.py
+++ b/edx_event_bus_kafka/internal/tests/test_consumer.py
@@ -4,7 +4,6 @@ Tests for event_consumer module.
 
 import copy
 from datetime import datetime
-from typing import Optional
 from unittest.mock import Mock, call, patch
 from uuid import uuid1
 
@@ -17,6 +16,7 @@ from openedx_events.learning.data import UserData, UserPersonalData
 from openedx_events.learning.signals import SESSION_LOGIN_COMPLETED
 
 from edx_event_bus_kafka.internal.consumer import KafkaEventConsumer, ReceiverError, UnusableMessageError
+from edx_event_bus_kafka.internal.tests.test_utils import FakeMessage, side_effects
 from edx_event_bus_kafka.management.commands.consume_events import Command
 
 # See https://github.com/openedx/event-bus-kafka/blob/main/docs/decisions/0005-optional-import-of-confluent-kafka.rst
@@ -31,86 +31,6 @@ try:
     from confluent_kafka.error import ConsumeError
 except ImportError as e:  # pragma: no cover
     pass
-
-
-def side_effects(functions: list):
-    """
-    Given a list of functions, return a new function that will call each one in turn
-    on successive invocations. (The returned function ignores any arguments it is
-    called with.) Each function's return value will be returned. Behavior is
-    undefined if insufficient functions are supplied.
-    """
-    f_iter = iter(functions)
-
-    def inner(*_args, **_kwargs):
-        nonlocal f_iter
-        return next(f_iter)()
-
-    return inner
-
-
-class TestUtils(TestCase):
-    """Tests for local unit test utilities."""
-
-    def test_side_effects(self):
-        f = side_effects([
-            lambda: 5,
-            lambda: 1/0,
-            lambda: 6,
-        ])
-        assert f() == 5
-        with pytest.raises(ArithmeticError):
-            f()
-        assert f(1, 2, 3, a=4, b=5) == 6
-
-
-class FakeMessage:
-    """
-    A fake confluent_kafka.cimpl.Message that we can actually construct for mocking.
-
-    See https://docs.confluent.io/platform/current/clients/confluent-kafka-python/html/index.html#message
-    """
-
-    def __init__(
-            self, topic: Optional[str] = None, partition: Optional[int] = None, offset: Optional[int] = None,
-            headers: Optional[list] = None, key: Optional[bytes] = None, value=None,
-            error=None, timestamp=None
-    ):
-        self._topic = topic
-        self._partition = partition
-        self._offset = offset
-        self._headers = headers
-        self._key = key
-        self._value = value
-        self._error = error
-        self._timestamp = timestamp
-
-    def topic(self) -> Optional[str]:
-        return self._topic
-
-    def partition(self) -> Optional[int]:
-        return self._partition
-
-    def offset(self) -> Optional[int]:
-        return self._offset
-
-    def headers(self) -> Optional[list]:
-        """List of str/bytes key/value pairs."""
-        return self._headers
-
-    def key(self) -> Optional[bytes]:
-        """Bytes (Avro)."""
-        return self._key
-
-    def value(self):
-        """Deserialized event value."""
-        return self._value
-
-    def error(self):
-        return self._error
-
-    def timestamp(self):
-        return self._timestamp
 
 
 def fake_receiver_returns_quietly(**kwargs):


### PR DESCRIPTION
`evt.headers()` turns out to be unpopulated, so use the bound context data
instead. Addresses https://github.com/openedx/event-bus-kafka/issues/128

Also:

- Move some test utilities out of the consumer tests and into test_utils.py (separate commit)
- Use FakeMessage rather than mock
- Fix previous release's date in changelog

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
- [x] Noted any: Concerns, dependencies, deadlines, tickets, testing instructions
