### PR TITLE
fix: load all signals in consume_events

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,13 @@ Change Log
 Unreleased
 **********
 
+[3.9.5] - 2023-02-24
+********************
+
+Fixed
+=====
+* load all signals in consume_events command before running the consumer
+
 [3.9.4] - 2023-02-16
 ********************
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,7 @@ Unreleased
 
 Fixed
 =====
-* load all signals in consume_events command before running the consumer
+* ``consume_events`` command now loads all public signals so that the consumer can load signals by ``event_type`` even if their modules were not already imported
 
 [3.9.4] - 2023-02-16
 ********************

--- a/edx_event_bus_kafka/__init__.py
+++ b/edx_event_bus_kafka/__init__.py
@@ -9,4 +9,4 @@ See ADR ``docs/decisions/0006-public-api-and-app-organization.rst`` for the reas
 from edx_event_bus_kafka.internal.consumer import KafkaEventConsumer
 from edx_event_bus_kafka.internal.producer import KafkaEventProducer, create_producer
 
-__version__ = '3.9.4'
+__version__ = '3.9.5'

--- a/edx_event_bus_kafka/internal/consumer.py
+++ b/edx_event_bus_kafka/internal/consumer.py
@@ -12,7 +12,7 @@ from django.db import connection
 from edx_django_utils.monitoring import record_exception, set_custom_attribute
 from edx_toggles.toggles import SettingToggle
 from openedx_events.event_bus.avro.deserializer import AvroSignalDeserializer
-from openedx_events.tooling import OpenEdxPublicSignal
+from openedx_events.tooling import OpenEdxPublicSignal, load_all_signals
 
 from .config import get_full_topic, get_schema_registry_client, load_common_settings
 from .utils import (
@@ -622,6 +622,7 @@ class ConsumeEventsCommand(BaseCommand):
             return
 
         try:
+            load_all_signals()
             signal = OpenEdxPublicSignal.get_signal_by_type(options['signal'][0])
             if options['offset_time'] and options['offset_time'][0] is not None:
                 try:

--- a/edx_event_bus_kafka/internal/tests/test_consumer.py
+++ b/edx_event_bus_kafka/internal/tests/test_consumer.py
@@ -653,16 +653,3 @@ class TestCommand(TestCase):
         call_command(Command(), topic='test', group_id='test', signal='openedx', offset_time=['notatimestamp'])
         mock_logger.exception.assert_any_call("Could not parse the offset timestamp.")
         mock_logger.exception.assert_called_with("Error consuming Kafka events")
-
-    def test_all_signals_loaded_before_lookup(self):
-        """
-        Test that all signals are loaded before get_signal_by_type
-
-        This is a little fragile because it assumes that
-        """
-        call_command(
-            Command(),
-            topic='test',
-            group_id='test',
-            signal='openedx',
-        )

--- a/edx_event_bus_kafka/internal/tests/test_consumer.py
+++ b/edx_event_bus_kafka/internal/tests/test_consumer.py
@@ -653,3 +653,16 @@ class TestCommand(TestCase):
         call_command(Command(), topic='test', group_id='test', signal='openedx', offset_time=['notatimestamp'])
         mock_logger.exception.assert_any_call("Could not parse the offset timestamp.")
         mock_logger.exception.assert_called_with("Error consuming Kafka events")
+
+    def test_all_signals_loaded_before_lookup(self):
+        """
+        Test that all signals are loaded before get_signal_by_type
+
+        This is a little fragile because it assumes that
+        """
+        call_command(
+            Command(),
+            topic='test',
+            group_id='test',
+            signal='openedx',
+        )

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,7 +2,7 @@
 -c constraints.txt
 
 Django                                  # Web application framework
-# openedx-events 5.0.0 has a breaking API change that requires code changes in this library
-openedx-events>=5.0.0                   # Events API
+# openedx-events 6.0.0 has load_all_signals()
+openedx-events>=6.0.0                   # Events API
 edx_django_utils
 edx_toggles


### PR DESCRIPTION
Issue: https://github.com/openedx/event-bus-kafka/issues/135
Blocked on https://github.com/openedx/openedx-events/pull/187

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] Noted any: Concerns, dependencies, deadlines, tickets, testing instructions