### PR TITLE
fix: Remove yanked codecov package

### DIFF
--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -1,5 +1,4 @@
 # Requirements for running tests on CI
 -c constraints.txt
 
-codecov                   # Code coverage reporting
 tox                       # Virtualenv management for tests

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,22 +4,12 @@
 #
 #    make upgrade
 #
-certifi==2022.12.7
-    # via requests
-charset-normalizer==3.1.0
-    # via requests
-codecov==2.1.12
-    # via -r requirements/ci.in
-coverage==7.2.1
-    # via codecov
 distlib==0.3.6
     # via virtualenv
 filelock==3.9.0
     # via
     #   tox
     #   virtualenv
-idna==3.4
-    # via requests
 packaging==23.0
     # via tox
 platformdirs==3.1.1
@@ -28,8 +18,6 @@ pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-requests==2.28.2
-    # via codecov
 six==1.16.0
     # via tox
 tomli==2.0.1
@@ -38,7 +26,5 @@ tox==3.28.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/ci.in
-urllib3==1.26.15
-    # via requests
 virtualenv==20.21.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -32,7 +32,6 @@ build==0.10.0
     #   pip-tools
 certifi==2022.12.7
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
 cffi==1.15.1
@@ -44,7 +43,6 @@ chardet==5.1.0
     # via diff-cover
 charset-normalizer==3.1.0
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
 click==8.1.3
@@ -65,15 +63,11 @@ code-annotations==1.3.0
     #   -r requirements/quality.txt
     #   edx-lint
     #   edx-toggles
-codecov==2.1.12
-    # via -r requirements/ci.txt
 confluent-kafka[avro,schema-registry]==2.0.2
     # via -r requirements/quality.txt
 coverage[toml]==7.2.1
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-    #   codecov
     #   pytest-cov
 cryptography==39.0.2
     # via
@@ -144,7 +138,6 @@ filelock==3.9.0
     #   virtualenv
 idna==3.4
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
 importlib-metadata==6.0.0
@@ -329,9 +322,7 @@ readme-renderer==37.3
     #   twine
 requests==2.28.2
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-    #   codecov
     #   confluent-kafka
     #   requests-toolbelt
     #   twine
@@ -408,7 +399,6 @@ typing-extensions==4.5.0
     #   rich
 urllib3==1.26.15
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
     #   twine


### PR DESCRIPTION
Already using the GitHub Action (of the latest version).

https://community.codecov.com/t/codecov-yanked-from-pypi-all-versions/4259

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
- [x] Noted any: Concerns, dependencies, deadlines, tickets, testing instructions
