### PR TITLE
feat: determine signal from message header

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,9 +14,14 @@ Change Log
 Unreleased
 **********
 
+[3.10.0] - 2023-05-05
+*********************
+Changed
+=======
 * Switch from ``edx-sphinx-theme`` to ``sphinx-book-theme`` since the former is
   deprecated
 * Refactored consumer to manually deserialize messages instead of using DeserializingConsumer
+* Make signal argument optional in consumer command (take signal from message headers)
 
 [3.9.6] - 2023-02-24
 ********************

--- a/edx_event_bus_kafka/__init__.py
+++ b/edx_event_bus_kafka/__init__.py
@@ -9,4 +9,4 @@ See ADR ``docs/decisions/0006-public-api-and-app-organization.rst`` for the reas
 from edx_event_bus_kafka.internal.consumer import KafkaEventConsumer
 from edx_event_bus_kafka.internal.producer import KafkaEventProducer, create_producer
 
-__version__ = '3.9.6'
+__version__ = '3.10.0'


### PR DESCRIPTION
Issue: https://github.com/openedx/openedx-events/issues/78

When consuming events, determine the correct signal to use from the message header rather than an argument passed into the management command. This is a necessary step towards allowing multiple event types on a single topic.
Temporarily makes the `signal` argument optional so it can be safely removed from callers without needing a lockstep upgrade. After we are reasonably certain we have upgraded any processes using the management command, we can make the breaking change and do a major version upgrade.

Also, since Consumer.poll() may return a message with an error object, remove misleading documentation saying it can't. DeserializingConsumer turned those errors into exceptions but the plain Consumer will keep them as errors on the message.