### PR TITLE
fix: add signal back as optional param

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 **********
 
+[4.0.1] - 2023-05-10
+********************
+Fixed
+=====
+* Added ``signal`` back as an argument when creating a consumer for compatibility with the openedx-events API
+
 [4.0.0] - 2023-05-10
 ********************
 Changed

--- a/edx_event_bus_kafka/__init__.py
+++ b/edx_event_bus_kafka/__init__.py
@@ -9,4 +9,4 @@ See ADR ``docs/decisions/0006-public-api-and-app-organization.rst`` for the reas
 from edx_event_bus_kafka.internal.consumer import KafkaEventConsumer
 from edx_event_bus_kafka.internal.producer import KafkaEventProducer, create_producer
 
-__version__ = '4.0.0'
+__version__ = '4.0.1'

--- a/edx_event_bus_kafka/internal/consumer.py
+++ b/edx_event_bus_kafka/internal/consumer.py
@@ -118,7 +118,7 @@ class KafkaEventConsumer(EventBusConsumer):
             consumers will only reset the offsets of the topic but will not actually consume and process any messages.
     """
 
-    def __init__(self, topic, group_id, signal=None, offset_time=None):
+    def __init__(self, topic, group_id, signal=None, offset_time=None):  # pylint: disable=unused-argument
         if confluent_kafka is None:  # pragma: no cover
             raise Exception('Library confluent-kafka not available. Cannot create event consumer.')
 

--- a/edx_event_bus_kafka/internal/consumer.py
+++ b/edx_event_bus_kafka/internal/consumer.py
@@ -112,13 +112,13 @@ class KafkaEventConsumer(EventBusConsumer):
     Attributes:
         topic: Topic to consume (without environment prefix).
         group_id: Consumer group id.
-        signal: Type of signal to emit from consumed messages.
+        signal: DEPRECATED Type of signal to emit from consumed messages. Will be removed in a future version
         consumer: Actual kafka consumer instance.
         offset_time: The timestamp (in ISO format) that we would like to reset the consumers to. If this is used, the
             consumers will only reset the offsets of the topic but will not actually consume and process any messages.
     """
 
-    def __init__(self, topic, group_id, offset_time=None):
+    def __init__(self, topic, group_id, signal=None, offset_time=None):
         if confluent_kafka is None:  # pragma: no cover
             raise Exception('Library confluent-kafka not available. Cannot create event consumer.')
 


### PR DESCRIPTION
Re-add the 'signal' parameter to the KafkaEventConsumer, as is expected by the EventBusConsumer API.

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] Noted any: Concerns, dependencies, deadlines, tickets, testing instructions