### PR TITLE
feat: use topic record name strategy

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,13 @@ Change Log
 Unreleased
 **********
 
-[5.0.0] - 2023-05-17
+[5.1.0] - 2023-05-16
+********************
+Changed
+=======
+* Reconfigured serializers to use topic_record_name_strategy, allowing multiple event types per topic
+
+[5.0.0] - 2023-05-16
 ********************
 Changed
 =======

--- a/edx_event_bus_kafka/__init__.py
+++ b/edx_event_bus_kafka/__init__.py
@@ -9,4 +9,4 @@ See ADR ``docs/decisions/0006-public-api-and-app-organization.rst`` for the reas
 from edx_event_bus_kafka.internal.consumer import KafkaEventConsumer
 from edx_event_bus_kafka.internal.producer import KafkaEventProducer, create_producer
 
-__version__ = '5.0.0'
+__version__ = '5.1.0'

--- a/edx_event_bus_kafka/internal/producer.py
+++ b/edx_event_bus_kafka/internal/producer.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 try:
     import confluent_kafka
     from confluent_kafka import Producer
+    from confluent_kafka.schema_registry import topic_record_subject_name_strategy
     from confluent_kafka.schema_registry.avro import AvroSerializer
     from confluent_kafka.serialization import MessageField, SerializationContext
 except ImportError:  # pragma: no cover
@@ -165,11 +166,13 @@ def get_serializers(signal: OpenEdxPublicSignal, event_key_field: str):
         schema_str=extract_key_schema(signal_serializer, event_key_field),
         schema_registry_client=client,
         to_dict=inner_to_dict,
+        conf={'subject.name.strategy': topic_record_subject_name_strategy},
     )
     value_serializer = AvroSerializer(
         schema_str=signal_serializer.schema_string(),
         schema_registry_client=client,
         to_dict=inner_to_dict,
+        conf={'subject.name.strategy': topic_record_subject_name_strategy},
     )
 
     return key_serializer, value_serializer

--- a/edx_event_bus_kafka/internal/producer.py
+++ b/edx_event_bus_kafka/internal/producer.py
@@ -161,19 +161,31 @@ def get_serializers(signal: OpenEdxPublicSignal, event_key_field: str):
         """Tells Avro how to turn objects into dictionaries."""
         return signal_serializer.to_dict(event_data)
 
+    # .. setting_name: EVENT_BUS_KAFKA_ALLOW_MULTIPLE_EVENTS_PER_TOPIC
+    # .. setting_default: False
+    # .. setting_description: Boolean determining whether Kafka topics will be allowed to have
+    # more than one event type on them. Useful if you have multiple events representing the lifecycle
+    # of a single object (eg XBLOCK_CREATED, XBLOCK_UPDATED, XBLOCK_DELETED). If set to True, will configure
+    # the producer to use the TopicRecordName strategy when registering schemas. See "Subject Name Strategy" in
+    # https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html
+    allow_mutiple_events_per_topic = getattr(settings, 'EVENT_BUS_KAFKA_ALLOW_MULTIPLE_EVENTS_PER_TOPIC', None)
+
     # Serializers for key and value components of Kafka event
     key_serializer = AvroSerializer(
         schema_str=extract_key_schema(signal_serializer, event_key_field),
         schema_registry_client=client,
         to_dict=inner_to_dict,
-        conf={'subject.name.strategy': topic_record_subject_name_strategy},
     )
+
     value_serializer = AvroSerializer(
         schema_str=signal_serializer.schema_string(),
         schema_registry_client=client,
         to_dict=inner_to_dict,
-        conf={'subject.name.strategy': topic_record_subject_name_strategy},
     )
+
+    if allow_mutiple_events_per_topic:
+        key_serializer['conf'] = {'subject.name.strategy': topic_record_subject_name_strategy}
+        value_serializer['conf'] = {'subject.name.strategy': topic_record_subject_name_strategy}
 
     return key_serializer, value_serializer
 

--- a/edx_event_bus_kafka/internal/tests/test_producer.py
+++ b/edx_event_bus_kafka/internal/tests/test_producer.py
@@ -26,6 +26,7 @@ from edx_event_bus_kafka.management.commands.produce_event import Command
 
 # See https://github.com/openedx/event-bus-kafka/blob/main/docs/decisions/0005-optional-import-of-confluent-kafka.rst
 try:
+    from confluent_kafka.schema_registry import topic_record_subject_name_strategy
     from confluent_kafka.schema_registry.avro import AvroSerializer
 except ImportError:  # pragma: no cover
     pass
@@ -79,6 +80,10 @@ class TestEventProducer(TestCase):
             # We can't actually call them because they want to talk to the schema server.
             assert isinstance(key_ser, AvroSerializer)
             assert isinstance(value_ser, AvroSerializer)
+            assert key_ser._subject_name_func ==\
+                   topic_record_subject_name_strategy  # pylint: disable=protected-access,comparison-with-callable
+            assert value_ser._subject_name_func ==\
+                   topic_record_subject_name_strategy  # pylint: disable=protected-access,comparison-with-callable
 
     def test_serializers_unconfigured(self):
         with pytest.raises(Exception, match="missing library or settings"):


### PR DESCRIPTION
Update serializers to allow multiple event types per topic. See https://docs.openedx.org/projects/event-bus-kafka/en/latest/decisions/0011_multiple_event_types_per_topic.html for the full explanation of why.

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] Noted any: Concerns, dependencies, deadlines, tickets, testing instructions
