### PR TITLE
feat: add json-formatted event data to error logs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 **********
 
+[5.2.0] - 2023-08-03
+********************
+Changed
+=======
+* Added event_data_as_dict to ProducingContext for easier replay from logs
+
 [5.1.0] - 2023-05-17
 ********************
 Changed

--- a/edx_event_bus_kafka/__init__.py
+++ b/edx_event_bus_kafka/__init__.py
@@ -9,4 +9,4 @@ See ADR ``docs/decisions/0006-public-api-and-app-organization.rst`` for the reas
 from edx_event_bus_kafka.internal.consumer import KafkaEventConsumer
 from edx_event_bus_kafka.internal.producer import KafkaEventProducer, create_producer
 
-__version__ = '5.1.0'
+__version__ = '5.2.0'

--- a/edx_event_bus_kafka/internal/producer.py
+++ b/edx_event_bus_kafka/internal/producer.py
@@ -135,6 +135,7 @@ def extract_key_schema(signal_serializer: AvroSignalSerializer, event_key_field:
     # Same as used by AvroSignalSerializer#schema_string in openedx-events
     return json.dumps(subschema, sort_keys=True)
 
+
 @lru_cache()
 def get_signal_serializer(signal: OpenEdxPublicSignal):
     """
@@ -149,6 +150,7 @@ def get_signal_serializer(signal: OpenEdxPublicSignal):
         An AvroSignalSerializer configured to serialize event data to dictionaries
     """
     return AvroSignalSerializer(signal)
+
 
 @lru_cache
 def get_serializers(signal: OpenEdxPublicSignal, event_key_field: str):
@@ -238,6 +240,7 @@ class ProducingContext:
                 f"Message delivered to Kafka event bus: topic={evt.topic()}, partition={evt.partition()}, "
                 f"offset={evt.offset()}, message_id={message_id}, key={evt.key()}"
             )
+
 
 class KafkaEventProducer(EventBusProducer):
     """

--- a/edx_event_bus_kafka/internal/producer.py
+++ b/edx_event_bus_kafka/internal/producer.py
@@ -379,3 +379,4 @@ def create_producer() -> Optional[KafkaEventProducer]:
 def _reset_caches(sender, **kwargs):  # pylint: disable=unused-argument
     """Reset caches when settings change during unit tests."""
     get_serializers.cache_clear()
+    get_signal_serializer.cache_clear()

--- a/edx_event_bus_kafka/internal/producer.py
+++ b/edx_event_bus_kafka/internal/producer.py
@@ -135,13 +135,27 @@ def extract_key_schema(signal_serializer: AvroSignalSerializer, event_key_field:
     # Same as used by AvroSignalSerializer#schema_string in openedx-events
     return json.dumps(subschema, sort_keys=True)
 
+@lru_cache()
+def get_signal_serializer(signal: OpenEdxPublicSignal):
+    """
+    Get the AvroSignalSerializer for a signal
+
+    This is cached in order to save work re-transforming classes into Avro schemas.
+
+    Arguments:
+        signal: The OpenEdxPublicSignal to make a serializer for.
+
+    Returns:
+        An AvroSignalSerializer configured to serialize event data to dictionaries
+    """
+    return AvroSignalSerializer(signal)
 
 @lru_cache
 def get_serializers(signal: OpenEdxPublicSignal, event_key_field: str):
     """
-    Get the key and value serializers for a signal and a key field path.
+    Get the full key and value serializers for a signal and a key field path.
 
-    This is cached in order to save work re-transforming classes into Avro schemas.
+    This is cached in order to save work re-transforming AvroSignalSerializers into AvroSerializers.
 
     Arguments:
         signal: The OpenEdxPublicSignal to make a serializer for.
@@ -149,13 +163,13 @@ def get_serializers(signal: OpenEdxPublicSignal, event_key_field: str):
           (period-delimited string naming the field names to descend).
 
     Returns:
-        2-tuple of AvroSignalSerializers, for event key and value
+        2-tuple of AvroSerializers, for event key and value
     """
     client = get_schema_registry_client()
     if client is None:
         raise Exception('Cannot create Kafka serializers -- missing library or settings')
 
-    signal_serializer = AvroSignalSerializer(signal)
+    signal_serializer = get_signal_serializer(signal)
 
     def inner_to_dict(event_data, ctx=None):  # pylint: disable=unused-argument
         """Tells Avro how to turn objects into dictionaries."""
@@ -191,6 +205,7 @@ class ProducingContext:
     event_key_field = attr.ib(type=str, default=None)
     event_data = attr.ib(type=dict, default=None)
     event_metadata = attr.ib(type=EventsMetadata, default=None)
+    event_data_as_json = attr.ib(type=str, default=None)
 
     def __repr__(self):
         """Create a logging-friendly string"""
@@ -223,7 +238,6 @@ class ProducingContext:
                 f"Message delivered to Kafka event bus: topic={evt.topic()}, partition={evt.partition()}, "
                 f"offset={evt.offset()}, message_id={message_id}, key={evt.key()}"
             )
-
 
 class KafkaEventProducer(EventBusProducer):
     """
@@ -266,6 +280,7 @@ class KafkaEventProducer(EventBusProducer):
         context = ProducingContext(signal=signal, initial_topic=topic, event_key_field=event_key_field,
                                    event_data=event_data, event_metadata=event_metadata)
         try:
+            context.event_data_as_json = json.dumps(get_signal_serializer(signal).to_dict(event_data))
             full_topic = get_full_topic(topic)
             context.full_topic = full_topic
 

--- a/edx_event_bus_kafka/internal/tests/test_producer.py
+++ b/edx_event_bus_kafka/internal/tests/test_producer.py
@@ -245,6 +245,8 @@ class TestEventProducer(TestCase):
         assert "source='openedx/test/web'" in error_string
         assert f"id=UUID('{metadata.id}')" in error_string
         assert f"sourcehost='{metadata.sourcehost}'" in error_string
+        assert f"event_data_as_json='{{\"test_data\": {{\"course_id\": \"id\", \"sub_name\": \"name\"}}}}'"\
+               in error_string
 
     @patch(
         'edx_event_bus_kafka.internal.producer.get_serializers', autospec=True,
@@ -283,6 +285,8 @@ class TestEventProducer(TestCase):
         # since we didn't fail until after key extraction we should have an event_key to report
         assert "event_key='ABCx'" in error_string
         assert "error=bad!" in error_string
+        assert f"event_data_as_json='{{\"test_data\": {{\"course_id\": \"ABCx\", \"sub_name\": \"name\"}}}}'"\
+               in error_string
 
     @override_settings(EVENT_BUS_KAFKA_POLL_INTERVAL_SEC=0.05)
     def test_polling_loop_terminates(self):

--- a/edx_event_bus_kafka/internal/tests/test_producer.py
+++ b/edx_event_bus_kafka/internal/tests/test_producer.py
@@ -285,7 +285,7 @@ class TestEventProducer(TestCase):
         # since we didn't fail until after key extraction we should have an event_key to report
         assert "event_key='ABCx'" in error_string
         assert "error=bad!" in error_string
-        assert f"event_data_as_json='{{\"test_data\": {{\"course_id\": \"ABCx\", \"sub_name\": \"name\"}}}}'"\
+        assert "event_data_as_json='{{\"test_data\": {{\"course_id\": \"ABCx\", \"sub_name\": \"name\"}}}}'"\
                in error_string
 
     @override_settings(EVENT_BUS_KAFKA_POLL_INTERVAL_SEC=0.05)

--- a/edx_event_bus_kafka/internal/tests/test_producer.py
+++ b/edx_event_bus_kafka/internal/tests/test_producer.py
@@ -245,7 +245,7 @@ class TestEventProducer(TestCase):
         assert "source='openedx/test/web'" in error_string
         assert f"id=UUID('{metadata.id}')" in error_string
         assert f"sourcehost='{metadata.sourcehost}'" in error_string
-        assert f"event_data_as_json='{{\"test_data\": {{\"course_id\": \"id\", \"sub_name\": \"name\"}}}}'"\
+        assert "event_data_as_json='{\"test_data\": {\"course_id\": \"id\", \"sub_name\": \"name\"}}'"\
                in error_string
 
     @patch(
@@ -285,7 +285,7 @@ class TestEventProducer(TestCase):
         # since we didn't fail until after key extraction we should have an event_key to report
         assert "event_key='ABCx'" in error_string
         assert "error=bad!" in error_string
-        assert "event_data_as_json='{{\"test_data\": {{\"course_id\": \"ABCx\", \"sub_name\": \"name\"}}}}'"\
+        assert "event_data_as_json='{\"test_data\": {\"course_id\": \"ABCx\", \"sub_name\": \"name\"}}'"\
                in error_string
 
     @override_settings(EVENT_BUS_KAFKA_POLL_INTERVAL_SEC=0.05)


### PR DESCRIPTION
Adds event_data_as_json to the error log when an event is not published. This will make it easier to recreate the event from the logs using an AvroSignalDeserializer.

Added the field instead of replacing the event data field so we will still get the event that was passed to the send method even if something in the serializer throws an error on creation. Also left everything else in the `=` format because Splunk is actually parsing them correctly as fields, it was just the nested event data it had trouble with. 

To test, set up your event bus to point to the dev cluster but with an incorrect schema registry password. When trying to fire an event, you should see an error like 
``
Error delivering message to Kafka event bus. error=Unauthorized (HTTP status code 401, SR code 401) full_topic='dev-graber-course-catalog-info-changed' event_key=CourseLocator('edX', 'DemoX', 'Demo_Course', None, None) signal=<OpenEdxPublicSignal: org.openedx.content_authoring.course.catalog_info.changed.v1> initial_topic='course-catalog-info-changed' event_key_field='catalog_info.course_key' event_data={'catalog_info': CourseCatalogData(course_key=CourseLocator('edX', 'DemoX', 'Demo_Course', None, None), name='Demonstration Course', schedule_data=CourseScheduleData(start=datetime.datetime(2013, 2, 5, 5, 0, tzinfo=<bson.tz_util.FixedOffset object at 0xffff58196b80>), pacing='instructor', end=None, enrollment_start=datetime.datetime(2013, 2, 5, 0, 0, tzinfo=<bson.tz_util.FixedOffset object at 0xffff58196b80>), enrollment_end=None), hidden=False, invitation_only=False)} event_metadata=EventsMetadata(event_type='org.openedx.content_authoring.course.catalog_info.changed.v1', id=UUID('065c50fe-3218-11ee-bfb5-0242ac15000c'), minorversion=0, source='openedx/cms/web', sourcehost='cms.devstack.edx', time=datetime.datetime(2023, 8, 3, 16, 8, 44, 784693, tzinfo=datetime.timezone.utc), sourcelib=(8, 3, 0)) event_data_as_json='{"catalog_info": {"course_key": "course-v1:edX+DemoX+Demo_Course", "hidden": false, "invitation_only": false, "name": "Demonstration Course", "schedule_data": {"end": null, "enrollment_end": null, "enrollment_start": "2013-02-05T00:00:00+00:00", "pacing": "instructor", "start": "2013-02-05T05:00:00+00:00"}}}'
``
(note the event_data_as_json field).

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [x] Noted any: Concerns, dependencies, deadlines, tickets, testing instructions
