### PR TITLE
feat: add event metadata as json to publish error logs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 **********
 
+[5.3.0] - 2023-08-08
+********************
+Changed
+=======
+* Added event_metadata_as_dict to ProducingContext for easier replay from logs
+
 [5.2.0] - 2023-08-03
 ********************
 Changed

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ docs: ## generate Sphinx HTML documentation, including API docs
 	$(BROWSER)docs/_build/html/index.html
 
 # Define PIP_COMPILE_OPTS=-v to get more information during make upgrade.
-PIP_COMPILE = pip-compile
+PIP_COMPILE = pip-compile --upgrade $(PIP_COMPILE_OPTS)
 
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
 upgrade: ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ docs: ## generate Sphinx HTML documentation, including API docs
 	$(BROWSER)docs/_build/html/index.html
 
 # Define PIP_COMPILE_OPTS=-v to get more information during make upgrade.
-PIP_COMPILE = pip-compile --upgrade $(PIP_COMPILE_OPTS)
+PIP_COMPILE = pip-compile
 
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
 upgrade: ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in

--- a/edx_event_bus_kafka/__init__.py
+++ b/edx_event_bus_kafka/__init__.py
@@ -9,4 +9,4 @@ See ADR ``docs/decisions/0006-public-api-and-app-organization.rst`` for the reas
 from edx_event_bus_kafka.internal.consumer import KafkaEventConsumer
 from edx_event_bus_kafka.internal.producer import KafkaEventProducer, create_producer
 
-__version__ = '5.2.0'
+__version__ = '5.3.0'

--- a/edx_event_bus_kafka/internal/producer.py
+++ b/edx_event_bus_kafka/internal/producer.py
@@ -208,6 +208,7 @@ class ProducingContext:
     event_data = attr.ib(type=dict, default=None)
     event_metadata = attr.ib(type=EventsMetadata, default=None)
     event_data_as_json = attr.ib(type=str, default=None)
+    event_metadata_as_json = attr.ib(type=str, default=None)
 
     def __repr__(self):
         """Create a logging-friendly string"""
@@ -284,6 +285,7 @@ class KafkaEventProducer(EventBusProducer):
                                    event_data=event_data, event_metadata=event_metadata)
         try:
             context.event_data_as_json = json.dumps(get_signal_serializer(signal).to_dict(event_data))
+            context.event_metadata_as_json = event_metadata.to_json()
             full_topic = get_full_topic(topic)
             context.full_topic = full_topic
 

--- a/edx_event_bus_kafka/internal/tests/test_producer.py
+++ b/edx_event_bus_kafka/internal/tests/test_producer.py
@@ -247,6 +247,7 @@ class TestEventProducer(TestCase):
         assert f"sourcehost='{metadata.sourcehost}'" in error_string
         assert "event_data_as_json='{\"test_data\": {\"course_id\": \"id\", \"sub_name\": \"name\"}}'"\
                in error_string
+        assert f"event_metadata_as_json='{metadata.to_json()}'" in error_string
 
     @patch(
         'edx_event_bus_kafka.internal.producer.get_serializers', autospec=True,
@@ -287,6 +288,7 @@ class TestEventProducer(TestCase):
         assert "error=bad!" in error_string
         assert "event_data_as_json='{\"test_data\": {\"course_id\": \"ABCx\", \"sub_name\": \"name\"}}'"\
                in error_string
+        assert f"event_metadata_as_json='{metadata.to_json()}'" in error_string
 
     @override_settings(EVENT_BUS_KAFKA_POLL_INTERVAL_SEC=0.05)
     def test_polling_loop_terminates(self):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -48,7 +48,7 @@ markupsafe==2.1.3
     # via jinja2
 newrelic==8.8.1
     # via edx-django-utils
-openedx-events==8.3.0
+openedx-events==8.5.0
     # via -r requirements/base.in
 pbr==5.11.1
     # via stevedore

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -202,7 +202,7 @@ newrelic==8.8.1
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
-openedx-events==8.3.0
+openedx-events==8.5.0
     # via -r requirements/quality.txt
 packaging==23.1
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -152,7 +152,7 @@ newrelic==8.8.1
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-openedx-events==8.3.0
+openedx-events==8.5.0
     # via -r requirements/test.txt
 packaging==23.1
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -150,7 +150,7 @@ newrelic==8.8.1
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-openedx-events==8.3.0
+openedx-events==8.5.0
     # via -r requirements/test.txt
 packaging==23.1
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -88,7 +88,7 @@ newrelic==8.8.1
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-openedx-events==8.3.0
+openedx-events==8.5.0
     # via -r requirements/base.txt
 packaging==23.1
     # via pytest


### PR DESCRIPTION
Add metadata in json form to the error logs when events fail to publish. This will be useful for republishing the events later.
Issue: 
https://github.com/edx/edx-arch-experiments/issues/354


**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] Noted any: Concerns, dependencies, deadlines, tickets, testing instructions
