### PR TITLE
fix: Reorder context assignment in producer code.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Change Log
 Unreleased
 **********
 
+* Changed ordering of certain context assignments in producer code.
+
 [5.3.1] - 2023-08-10
 ********************
 Fixed

--- a/edx_event_bus_kafka/internal/producer.py
+++ b/edx_event_bus_kafka/internal/producer.py
@@ -284,13 +284,17 @@ class KafkaEventProducer(EventBusProducer):
         context = ProducingContext(signal=signal, initial_topic=topic, event_key_field=event_key_field,
                                    event_data=event_data, event_metadata=event_metadata)
         try:
-            context.event_data_as_json = json.dumps(get_signal_serializer(signal).to_dict(event_data))
-            context.event_metadata_as_json = event_metadata.to_json()
+            # Please keep these context assignments in order from least-likely-to-error to most-likely-to-error so that
+            # we have as much context as possible in error logging.
             full_topic = get_full_topic(topic)
             context.full_topic = full_topic
 
+            context.event_data_as_json = json.dumps(get_signal_serializer(signal).to_dict(event_data))
+            context.event_metadata_as_json = event_metadata.to_json()
+
             event_key = extract_event_key(event_data, event_key_field)
             context.event_key = event_key
+
             headers = _get_headers_from_metadata(event_metadata=event_metadata)
 
             key_serializer, value_serializer = get_serializers(signal, event_key_field)


### PR DESCRIPTION
In error logging, we did not have the full_topic
available for searching/alerting because of the order in which these assignments happened. Reordering them to try to ensure we always get the full_topic in context.

https://github.com/edx/edx-arch-experiments/issues/411


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
- [x] Noted any: Concerns, dependencies, deadlines, tickets, testing instructions
