### PR TITLE
feat: add configurable client.id to base settings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Unreleased
 ********************
 Changed
 =======
-* Added configurable client.id to base settings
+* Added configurable client.id to base configuration
 
 [5.5.0] - 2023-09-21
 ********************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 **********
 
+[5.6.0] - 2024-01-24
+********************
+Changed
+=======
+* Added configurable client.id to base settings
+
 [5.5.0] - 2023-09-21
 ********************
 Changed

--- a/edx_event_bus_kafka/__init__.py
+++ b/edx_event_bus_kafka/__init__.py
@@ -9,4 +9,4 @@ See ADR ``docs/decisions/0006-public-api-and-app-organization.rst`` for the reas
 from edx_event_bus_kafka.internal.consumer import KafkaEventConsumer
 from edx_event_bus_kafka.internal.producer import KafkaEventProducer, create_producer
 
-__version__ = '5.5.0'
+__version__ = '5.6.0'

--- a/edx_event_bus_kafka/internal/config.py
+++ b/edx_event_bus_kafka/internal/config.py
@@ -3,7 +3,6 @@ Configuration loading and validation.
 
 This module is for internal use only.
 """
-import logging
 import warnings
 from functools import lru_cache
 from typing import Optional
@@ -116,7 +115,6 @@ def load_common_settings() -> Optional[dict]:
     # .. Kafka will use 'rdkafka' as the identifier
     client_id = getattr(settings, 'EVENT_BUS_KAFKA_APP_NAME', None)
     if client_id:
-        print(f"{client_id=}")
         base_settings.update({
             'client.id': client_id
         })

--- a/edx_event_bus_kafka/internal/config.py
+++ b/edx_event_bus_kafka/internal/config.py
@@ -3,7 +3,7 @@ Configuration loading and validation.
 
 This module is for internal use only.
 """
-
+import logging
 import warnings
 from functools import lru_cache
 from typing import Optional
@@ -114,8 +114,9 @@ def load_common_settings() -> Optional[dict]:
     # .. setting_default: None
     # .. setting_description: Identifier for the producing/consuming application. Useful for debugging. If not set
     # .. Kafka will use 'rdkafka' as the identifier
-    client_id = getattr(settings, 'EVENT_BUS_KAFKA_APP_NAME')
+    client_id = getattr(settings, 'EVENT_BUS_KAFKA_APP_NAME', None)
     if client_id:
+        print(f"{client_id=}")
         base_settings.update({
             'client.id': client_id
         })

--- a/edx_event_bus_kafka/internal/config.py
+++ b/edx_event_bus_kafka/internal/config.py
@@ -110,6 +110,15 @@ def load_common_settings() -> Optional[dict]:
             'sasl.password': secret,
         })
 
+    # .. setting_name: EVENT_BUS_KAFKA_CLIENT_ID
+    # .. setting_default: None
+    # .. setting_description: Identifier for the producing/consuming application. Useful for debugging. If not set
+    # .. Kafka will use 'rdkafka' as the identifier
+    client_id = getattr(settings, 'EVENT_BUS_KAFKA_CLIENT_ID')
+    if client_id:
+        base_settings.update({
+            'client.id': client_id
+        })
     return base_settings
 
 

--- a/edx_event_bus_kafka/internal/config.py
+++ b/edx_event_bus_kafka/internal/config.py
@@ -114,7 +114,7 @@ def load_common_settings() -> Optional[dict]:
     # .. setting_default: None
     # .. setting_description: Identifier for the producing/consuming application. Useful for debugging. If not set
     # .. Kafka will use 'rdkafka' as the identifier
-    client_id = getattr(settings, 'EVENT_BUS_KAFKA_CLIENT_ID')
+    client_id = getattr(settings, 'EVENT_BUS_KAFKA_APP_NAME')
     if client_id:
         base_settings.update({
             'client.id': client_id

--- a/edx_event_bus_kafka/internal/config.py
+++ b/edx_event_bus_kafka/internal/config.py
@@ -113,7 +113,7 @@ def load_common_settings() -> Optional[dict]:
     # .. setting_default: None
     # .. setting_description: Identifier for the producing/consuming application. Useful for debugging. If not set
     # .. Kafka will use 'rdkafka' as the identifier
-    client_id = getattr(settings, 'EVENT_BUS_KAFKA_APP_NAME', None)
+    client_id = getattr(settings, 'EVENT_BUS_APP_NAME', None)
     if client_id:
         base_settings.update({
             'client.id': client_id

--- a/edx_event_bus_kafka/internal/tests/test_config.py
+++ b/edx_event_bus_kafka/internal/tests/test_config.py
@@ -50,7 +50,7 @@ class TestCommonSettings(TestCase):
                 EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321',
                 EVENT_BUS_KAFKA_API_KEY='some_other_key',
                 EVENT_BUS_KAFKA_API_SECRET='some_other_secret',
-                EVENT_BUS_KAFKA_APP_NAME='my_client_id',
+                EVENT_BUS_APP_NAME='my_client_id',
         ):
             assert config.load_common_settings() == {
                 'bootstrap.servers': 'localhost:54321',

--- a/edx_event_bus_kafka/internal/tests/test_config.py
+++ b/edx_event_bus_kafka/internal/tests/test_config.py
@@ -50,6 +50,7 @@ class TestCommonSettings(TestCase):
                 EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321',
                 EVENT_BUS_KAFKA_API_KEY='some_other_key',
                 EVENT_BUS_KAFKA_API_SECRET='some_other_secret',
+                EVENT_BUS_KAFKA_CLIENT_ID='my_client_id',
         ):
             assert config.load_common_settings() == {
                 'bootstrap.servers': 'localhost:54321',
@@ -57,6 +58,7 @@ class TestCommonSettings(TestCase):
                 'security.protocol': 'SASL_SSL',
                 'sasl.username': 'some_other_key',
                 'sasl.password': 'some_other_secret',
+                'client.id': 'my_client_id',
             }
 
 

--- a/edx_event_bus_kafka/internal/tests/test_config.py
+++ b/edx_event_bus_kafka/internal/tests/test_config.py
@@ -50,7 +50,7 @@ class TestCommonSettings(TestCase):
                 EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321',
                 EVENT_BUS_KAFKA_API_KEY='some_other_key',
                 EVENT_BUS_KAFKA_API_SECRET='some_other_secret',
-                EVENT_BUS_KAFKA_CLIENT_ID='my_client_id',
+                EVENT_BUS_KAFKA_APP_NAME='my_client_id',
         ):
             assert config.load_common_settings() == {
                 'bootstrap.servers': 'localhost:54321',


### PR DESCRIPTION
Allows configuring of the client id of producers and consumers so we can better track our message streams.

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [x] Noted any: Concerns, dependencies, deadlines, tickets, testing instructions
