### PR TITLE
fix: use new method for setting client id

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Unreleased
 ********************
 Changed
 =======
-* Added  client.id to base configuration.
+* Added client.id to base configuration.
 
 [5.5.0] - 2023-09-21
 ********************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,12 +14,11 @@ Change Log
 Unreleased
 **********
 
-[5.6.0] - 2024-01-24
+[5.6.0] - 2024-01-25
 ********************
 Changed
 =======
-* Added configurable client.id to base configuration. Derives from new setting EVENT_BUS_SERVICE_NAME
-
+* Added  client.id to base configuration.
 
 [5.5.0] - 2023-09-21
 ********************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,8 @@ Unreleased
 ********************
 Changed
 =======
-* Added configurable client.id to base configuration
+* Added configurable client.id to base configuration. Derives from new setting EVENT_BUS_SERVICE_NAME
+
 
 [5.5.0] - 2023-09-21
 ********************

--- a/edx_event_bus_kafka/internal/config.py
+++ b/edx_event_bus_kafka/internal/config.py
@@ -11,6 +11,8 @@ from django.conf import settings
 from django.dispatch import receiver
 from django.test.signals import setting_changed
 
+from openedx_events.data import get_service_name
+
 # See https://github.com/openedx/event-bus-kafka/blob/main/docs/decisions/0005-optional-import-of-confluent-kafka.rst
 try:
     import confluent_kafka
@@ -109,13 +111,7 @@ def load_common_settings() -> Optional[dict]:
             'sasl.password': secret,
         })
 
-    # .. setting_name: EVENT_BUS_SERVICE_NAME
-    # .. setting_default: None
-    # .. setting_description: Identifier for the producing/consuming service. If not set
-    #   Kafka will use 'rdkafka' as the identifier. For example, if using the event bus in course-discovery,
-    #   this setting should be set to "course-discovery" so it's clear in the Kafka stream where events are coming from.
-    #   Kafka calls this the "client id."
-    client_id = getattr(settings, 'EVENT_BUS_SERVICE_NAME', None)
+    client_id = get_service_name()
     if client_id:
         base_settings.update({
             'client.id': client_id

--- a/edx_event_bus_kafka/internal/config.py
+++ b/edx_event_bus_kafka/internal/config.py
@@ -109,11 +109,13 @@ def load_common_settings() -> Optional[dict]:
             'sasl.password': secret,
         })
 
-    # .. setting_name: EVENT_BUS_KAFKA_CLIENT_ID
+    # .. setting_name: EVENT_BUS_SERVICE_NAME
     # .. setting_default: None
-    # .. setting_description: Identifier for the producing/consuming application. Useful for debugging. If not set
-    # .. Kafka will use 'rdkafka' as the identifier
-    client_id = getattr(settings, 'EVENT_BUS_APP_NAME', None)
+    # .. setting_description: Identifier for the producing/consuming service. If not set
+    #   Kafka will use 'rdkafka' as the identifier. For example, if using the event bus in course-discovery,
+    #   this setting should be set to "course-discovery" so it's clear in the Kafka stream where events are coming from.
+    #   Kafka calls this the "client id."
+    client_id = getattr(settings, 'EVENT_BUS_SERVICE_NAME', None)
     if client_id:
         base_settings.update({
             'client.id': client_id

--- a/edx_event_bus_kafka/internal/config.py
+++ b/edx_event_bus_kafka/internal/config.py
@@ -10,7 +10,6 @@ from typing import Optional
 from django.conf import settings
 from django.dispatch import receiver
 from django.test.signals import setting_changed
-
 from openedx_events.data import get_service_name
 
 # See https://github.com/openedx/event-bus-kafka/blob/main/docs/decisions/0005-optional-import-of-confluent-kafka.rst

--- a/edx_event_bus_kafka/internal/tests/test_config.py
+++ b/edx_event_bus_kafka/internal/tests/test_config.py
@@ -50,7 +50,7 @@ class TestCommonSettings(TestCase):
                 EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321',
                 EVENT_BUS_KAFKA_API_KEY='some_other_key',
                 EVENT_BUS_KAFKA_API_SECRET='some_other_secret',
-                EVENT_BUS_SERVICE_NAME='my_service',
+                EVENTS_SERVICE_NAME='my_service',
         ):
             assert config.load_common_settings() == {
                 'bootstrap.servers': 'localhost:54321',

--- a/edx_event_bus_kafka/internal/tests/test_config.py
+++ b/edx_event_bus_kafka/internal/tests/test_config.py
@@ -50,7 +50,7 @@ class TestCommonSettings(TestCase):
                 EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321',
                 EVENT_BUS_KAFKA_API_KEY='some_other_key',
                 EVENT_BUS_KAFKA_API_SECRET='some_other_secret',
-                EVENT_BUS_APP_NAME='my_client_id',
+                EVENT_BUS_SERVICE_NAME='my_service',
         ):
             assert config.load_common_settings() == {
                 'bootstrap.servers': 'localhost:54321',
@@ -58,7 +58,7 @@ class TestCommonSettings(TestCase):
                 'security.protocol': 'SASL_SSL',
                 'sasl.username': 'some_other_key',
                 'sasl.password': 'some_other_secret',
-                'client.id': 'my_client_id',
+                'client.id': 'my_service',
             }
 
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,7 +2,7 @@
 -c constraints.txt
 
 Django                                  # Web application framework
-# openedx-events 8.5.0 adds serialization methods to EventsMetadata
-openedx-events>=8.5.0                   # Events API
+# openedx-events 9.3.0 adds get_service_name method
+openedx-events>=9.3.0                   # Events API
 edx_django_utils
 edx_toggles

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -49,7 +49,7 @@ markupsafe==2.1.4
     # via jinja2
 newrelic==9.5.0
     # via edx-django-utils
-openedx-events==9.2.0
+openedx-events==9.3.0
     # via -r requirements/base.in
 pbr==6.0.0
     # via stevedore

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -218,7 +218,7 @@ nh3==0.2.15
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
-openedx-events==9.2.0
+openedx-events==9.3.0
     # via -r requirements/quality.txt
 packaging==23.2
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -158,7 +158,7 @@ newrelic==9.5.0
     #   edx-django-utils
 nh3==0.2.15
     # via readme-renderer
-openedx-events==9.2.0
+openedx-events==9.3.0
     # via -r requirements/test.txt
 packaging==23.2
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -153,7 +153,7 @@ newrelic==9.5.0
     #   edx-django-utils
 nh3==0.2.15
     # via readme-renderer
-openedx-events==9.2.0
+openedx-events==9.3.0
     # via -r requirements/test.txt
 packaging==23.2
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -92,7 +92,7 @@ newrelic==9.5.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-openedx-events==9.2.0
+openedx-events==9.3.0
     # via -r requirements/base.txt
 packaging==23.2
     # via pytest


### PR DESCRIPTION
Use the new method in openedx-events instead of accessing the settings directly

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] Noted any: Concerns, dependencies, deadlines, tickets, testing instructions
