### PR TITLE
build: set custom django and python versions in kafka workers

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,3 +8,5 @@ omit =
     *admin.py
     *static*
     *templates*
+    */tests/*
+

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 **********
 
+[6.0.1] - 2025-04-05
+********************
+Added
+=======
+* Added support to test custom_attributes in kafka workers
+
 [6.0.0] - 2024-08-24
 ********************
 Added

--- a/edx_event_bus_kafka/__init__.py
+++ b/edx_event_bus_kafka/__init__.py
@@ -9,4 +9,4 @@ See ADR ``docs/decisions/0006-public-api-and-app-organization.rst`` for the reas
 from edx_event_bus_kafka.internal.consumer import KafkaEventConsumer
 from edx_event_bus_kafka.internal.producer import KafkaEventProducer, create_producer
 
-__version__ = '6.0.0'
+__version__ = '6.0.1'

--- a/edx_event_bus_kafka/internal/consumer.py
+++ b/edx_event_bus_kafka/internal/consumer.py
@@ -2,10 +2,12 @@
 Core consumer and event-loop code.
 """
 import logging
+import platform
 import time
 from datetime import datetime
 from functools import lru_cache
 
+import django
 from django.conf import settings
 from django.db import connection
 from django.dispatch import receiver
@@ -585,6 +587,12 @@ class KafkaEventConsumer(EventBusConsumer):
                 # .. custom_attribute_name: kafka_offset
                 # .. custom_attribute_description: The offset of the message.
                 set_custom_attribute('kafka_offset', kafka_message.offset())
+                # .. custom_attribute_name: django_version
+                # .. custom_attribute_description: The django version in use (e.g. '4.2.20')
+                set_custom_attribute('django_version', django.__version__)
+                # .. custom_attribute_name: python_version
+                # .. custom_attribute_description: The python version in use (e.g. '3.12.8')
+                set_custom_attribute('python_version', platform.python_version())
                 headers = kafka_message.headers() or []  # treat None as []
                 message_ids = get_message_header_values(headers, HEADER_ID)
                 if len(message_ids) > 0:


### PR DESCRIPTION
## Description
- PR created under the issue https://github.com/edx/edx-arch-experiments/issues/785
- Added custom `dajngo_version` and `python_version` attributes recording within the kafka workers.