### PR TITLE
feat: enhance Kafka consumer error logging

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,9 +16,10 @@ Unreleased
 
 [6.2.0] - 2026-03-20
 ********************
-Changed
-=======
-* Enhanced Kafka consumer error logging with comprehensive diagnostic context including service identification, pod name, Kafka configuration, runtime statistics (messages_processed, messages_failed, consecutive_errors, uptime_seconds), and operational metadata for improved production debugging in Datadog/Splunk.
+Added
+=====
+* Added EVENT_BUS_KAFKA_CONSUMER_CONFIG setting to allow custom Kafka consumer configuration overrides for testing and production tuning.
+* Added test coverage for Kafka control message handling in the consumer loop.
 
 [6.1.0] - 2025-04-09
 ********************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 **********
 
+[6.2.0] - 2026-03-20
+********************
+Changed
+=======
+* Enhanced Kafka consumer error logging with comprehensive diagnostic context including service identification, pod name, Kafka configuration, runtime statistics (messages_processed, messages_failed, consecutive_errors, uptime_seconds), and operational metadata for improved production debugging in Datadog/Splunk.
+
 [6.1.0] - 2025-04-09
 ********************
 Added

--- a/edx_event_bus_kafka/__init__.py
+++ b/edx_event_bus_kafka/__init__.py
@@ -9,4 +9,4 @@ See ADR ``docs/decisions/0006-public-api-and-app-organization.rst`` for the reas
 from edx_event_bus_kafka.internal.consumer import KafkaEventConsumer
 from edx_event_bus_kafka.internal.producer import KafkaEventProducer, create_producer
 
-__version__ = '6.1.0'
+__version__ = '6.2.0'

--- a/edx_event_bus_kafka/internal/consumer.py
+++ b/edx_event_bus_kafka/internal/consumer.py
@@ -279,26 +279,26 @@ class KafkaEventConsumer(EventBusConsumer):
 
         try:
             full_topic = get_full_topic(self.topic)
-            
+
             # Build comprehensive diagnostic context for error reporting
             run_context = {
                 'service': getattr(settings, 'EVENTS_SERVICE_NAME', 'unknown'),
                 'environment': getattr(settings, 'EVENT_BUS_TOPIC_PREFIX', 'unknown'),
-                
+
                 'full_topic': full_topic,
                 'consumer_group': self.group_id,
                 'kafka_bootstrap_servers': getattr(settings, 'EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS', 'unknown'),
                 'schema_registry_url': getattr(settings, 'EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL', 'unknown'),
-                
+
                 'consumer_poll_timeout_sec': CONSUMER_POLL_TIMEOUT,
                 'consecutive_errors_limit': CONSECUTIVE_ERRORS_LIMIT or 'unlimited',
-                
+
                 'pod_name': os.environ.get('HOSTNAME', os.environ.get('POD_NAME', 'unknown')),
                 'hostname': platform.node(),
-                
+
                 'consumer_started_at': datetime.now().isoformat(),
             }
-            
+
             self.consumer.subscribe([full_topic])
             logger.info(f"Running consumer for {run_context!r}")
 
@@ -308,7 +308,7 @@ class KafkaEventConsumer(EventBusConsumer):
             # being able to talk to the broker and get a message (or a normal poll timeout) is
             # not sufficient to show that progress can be made.
             consecutive_errors = 0
-            
+
             # Track runtime statistics for debugging
             messages_processed = 0
             messages_failed = 0
@@ -347,14 +347,14 @@ class KafkaEventConsumer(EventBusConsumer):
                     except Exception as e:
                         consecutive_errors += 1
                         messages_failed += 1
-                        
+
                         # Add runtime stats to error context
                         error_context = run_context.copy()
                         error_context['messages_processed'] = messages_processed
                         error_context['messages_failed'] = messages_failed
                         error_context['consecutive_errors'] = consecutive_errors
                         error_context['uptime_seconds'] = (datetime.now() - loop_start_time).total_seconds()
-                        
+
                         self.record_event_consuming_error(error_context, e, msg)
                         # Kill the infinite loop if the error is fatal for the consumer
                         _, kafka_error = self._get_kafka_message_and_error(message=msg, error=e)

--- a/edx_event_bus_kafka/internal/consumer.py
+++ b/edx_event_bus_kafka/internal/consumer.py
@@ -2,6 +2,7 @@
 Core consumer and event-loop code.
 """
 import logging
+import os
 import platform
 import time
 from datetime import datetime
@@ -278,10 +279,26 @@ class KafkaEventConsumer(EventBusConsumer):
 
         try:
             full_topic = get_full_topic(self.topic)
+            
+            # Build comprehensive diagnostic context for error reporting
             run_context = {
+                'service': getattr(settings, 'EVENTS_SERVICE_NAME', 'unknown'),
+                'environment': getattr(settings, 'EVENT_BUS_TOPIC_PREFIX', 'unknown'),
+                
                 'full_topic': full_topic,
                 'consumer_group': self.group_id,
+                'kafka_bootstrap_servers': getattr(settings, 'EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS', 'unknown'),
+                'schema_registry_url': getattr(settings, 'EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL', 'unknown'),
+                
+                'consumer_poll_timeout_sec': CONSUMER_POLL_TIMEOUT,
+                'consecutive_errors_limit': CONSECUTIVE_ERRORS_LIMIT or 'unlimited',
+                
+                'pod_name': os.environ.get('HOSTNAME', os.environ.get('POD_NAME', 'unknown')),
+                'hostname': platform.node(),
+                
+                'consumer_started_at': datetime.now().isoformat(),
             }
+            
             self.consumer.subscribe([full_topic])
             logger.info(f"Running consumer for {run_context!r}")
 
@@ -291,6 +308,11 @@ class KafkaEventConsumer(EventBusConsumer):
             # being able to talk to the broker and get a message (or a normal poll timeout) is
             # not sufficient to show that progress can be made.
             consecutive_errors = 0
+            
+            # Track runtime statistics for debugging
+            messages_processed = 0
+            messages_failed = 0
+            loop_start_time = datetime.now()
 
             while True:
                 # Allow unit tests to break out of loop
@@ -299,6 +321,10 @@ class KafkaEventConsumer(EventBusConsumer):
 
                 # Detect probably-broken consumer and exit with error.
                 if CONSECUTIVE_ERRORS_LIMIT and consecutive_errors >= CONSECUTIVE_ERRORS_LIMIT:
+                    # Add runtime stats to context before exiting
+                    run_context['messages_processed'] = messages_processed
+                    run_context['messages_failed'] = messages_failed
+                    run_context['uptime_seconds'] = (datetime.now() - loop_start_time).total_seconds()
                     raise Exception(f"Too many consecutive errors, exiting ({consecutive_errors} in a row)")
 
                 with function_trace('consumer.consume'):
@@ -315,11 +341,21 @@ class KafkaEventConsumer(EventBusConsumer):
                             msg.set_value(self._deserialize_message_value(msg, signal))
                             self.emit_signals_from_message(msg, signal)
                             consecutive_errors = 0
+                            messages_processed += 1
 
                         self._add_message_monitoring(run_context=run_context, message=msg)
                     except Exception as e:
                         consecutive_errors += 1
-                        self.record_event_consuming_error(run_context, e, msg)
+                        messages_failed += 1
+                        
+                        # Add runtime stats to error context
+                        error_context = run_context.copy()
+                        error_context['messages_processed'] = messages_processed
+                        error_context['messages_failed'] = messages_failed
+                        error_context['consecutive_errors'] = consecutive_errors
+                        error_context['uptime_seconds'] = (datetime.now() - loop_start_time).total_seconds()
+                        
+                        self.record_event_consuming_error(error_context, e, msg)
                         # Kill the infinite loop if the error is fatal for the consumer
                         _, kafka_error = self._get_kafka_message_and_error(message=msg, error=e)
                         if kafka_error and kafka_error.fatal():

--- a/edx_event_bus_kafka/internal/consumer.py
+++ b/edx_event_bus_kafka/internal/consumer.py
@@ -2,7 +2,6 @@
 Core consumer and event-loop code.
 """
 import logging
-import os
 import platform
 import time
 from datetime import datetime
@@ -280,21 +279,12 @@ class KafkaEventConsumer(EventBusConsumer):
         try:
             full_topic = get_full_topic(self.topic)
 
-            # Build comprehensive diagnostic context for error reporting
             run_context = {
-                'service': getattr(settings, 'EVENTS_SERVICE_NAME', 'unknown'),
-                'environment': getattr(settings, 'EVENT_BUS_TOPIC_PREFIX', 'unknown'),
-
                 'full_topic': full_topic,
                 'consumer_group': self.group_id,
-                'kafka_bootstrap_servers': getattr(settings, 'EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS', 'unknown'),
-                'schema_registry_url': getattr(settings, 'EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL', 'unknown'),
 
                 'consumer_poll_timeout_sec': CONSUMER_POLL_TIMEOUT,
                 'consecutive_errors_limit': CONSECUTIVE_ERRORS_LIMIT or 'unlimited',
-
-                'pod_name': os.environ.get('HOSTNAME', os.environ.get('POD_NAME', 'unknown')),
-                'hostname': platform.node(),
 
                 'consumer_started_at': datetime.now().isoformat(),
             }

--- a/edx_event_bus_kafka/internal/consumer.py
+++ b/edx_event_bus_kafka/internal/consumer.py
@@ -404,6 +404,12 @@ class KafkaEventConsumer(EventBusConsumer):
             signal (OpenEdxPublicSignal): Signal - must match the event_type of the message header.
         """
         self._log_message_received(msg)
+
+        if msg.error() is not None:
+            raise UnusableMessageError(
+                f"Polled message had error object: {msg.error()!r}"
+            )
+
         # This should also never happen since the signal should be determined from the message
         # but it's here to prevent misuse of the method
         msg_event_type = self._get_event_type_from_message(msg)

--- a/edx_event_bus_kafka/internal/consumer.py
+++ b/edx_event_bus_kafka/internal/consumer.py
@@ -332,6 +332,13 @@ class KafkaEventConsumer(EventBusConsumer):
                     try:
                         msg = self.consumer.poll(timeout=CONSUMER_POLL_TIMEOUT)
                         if msg is not None:
+                            if msg.error() is not None:
+                                error_code = msg.error().code()
+                                error_str = msg.error().str()
+                                logger.warning(
+                                    f"Received Kafka control/error message: {error_str} (code: {error_code})"
+                                )
+                                continue
                             # Before processing, try to make sure our application state is cleaned
                             # up as would happen at the start of a Django request/response cycle.
                             # See https://github.com/openedx/openedx-events/issues/236 for details.
@@ -397,12 +404,6 @@ class KafkaEventConsumer(EventBusConsumer):
             signal (OpenEdxPublicSignal): Signal - must match the event_type of the message header.
         """
         self._log_message_received(msg)
-
-        if msg.error() is not None:
-            raise UnusableMessageError(
-                f"Polled message had error object: {msg.error()!r}"
-            )
-
         # This should also never happen since the signal should be determined from the message
         # but it's here to prevent misuse of the method
         msg_event_type = self._get_event_type_from_message(msg)

--- a/edx_event_bus_kafka/internal/consumer.py
+++ b/edx_event_bus_kafka/internal/consumer.py
@@ -288,7 +288,6 @@ class KafkaEventConsumer(EventBusConsumer):
 
                 'consumer_started_at': datetime.now().isoformat(),
             }
-
             self.consumer.subscribe([full_topic])
             logger.info(f"Running consumer for {run_context!r}")
 
@@ -303,7 +302,6 @@ class KafkaEventConsumer(EventBusConsumer):
             messages_processed = 0
             messages_failed = 0
             loop_start_time = datetime.now()
-
             while True:
                 # Allow unit tests to break out of loop
                 if self._shut_down_loop:

--- a/edx_event_bus_kafka/internal/consumer.py
+++ b/edx_event_bus_kafka/internal/consumer.py
@@ -254,7 +254,7 @@ class KafkaEventConsumer(EventBusConsumer):
             time.sleep(30)
             continue
 
-    def _consume_indefinitely(self):
+    def _consume_indefinitely(self):  # pylint: disable=too-many-statements
         """
         Consume events from a topic in an infinite loop.
         """

--- a/edx_event_bus_kafka/internal/tests/test_consumer.py
+++ b/edx_event_bus_kafka/internal/tests/test_consumer.py
@@ -502,10 +502,10 @@ class TestEmitSignals(TestCase):
         EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321',
         EVENT_BUS_TOPIC_PREFIX='local',
     )
-    def test_control_message_in_consume_loop(self, mock_logger, mock_set_custom_attribute):
+    def test_control_message_in_consume_loop(self, mock_logger, _mock_set_custom_attribute):
         """
         Test that Kafka control/error messages are handled gracefully in the consume loop.
-        
+
         Control messages have msg.error() set and should be logged as warnings and skipped,
         not processed as CloudEvent messages.
         """
@@ -517,9 +517,9 @@ class TestEmitSignals(TestCase):
             key=None,
             headers=None,
         )
-        
+
         poll_call_count = [0]
-        
+
         def poll_side_effect(*args, **kwargs):
             poll_call_count[0] += 1
             if poll_call_count[0] == 1:
@@ -530,17 +530,17 @@ class TestEmitSignals(TestCase):
 
         mock_consumer = Mock(**{'poll.side_effect': poll_side_effect}, autospec=True)
         self.event_consumer.consumer = mock_consumer
-        
+
         self.event_consumer.consume_indefinitely()
-        
+
         mock_logger.warning.assert_called_once()
         warning_call_args = mock_logger.warning.call_args.args[0]
         assert "Received Kafka control/error message" in warning_call_args
         assert "-191" in warning_call_args
         assert "maximum poll interval" in warning_call_args.lower()
-        
+
         mock_consumer.commit.assert_not_called()
-        
+
         mock_logger.exception.assert_not_called()
 
     @override_settings(

--- a/edx_event_bus_kafka/internal/tests/test_consumer.py
+++ b/edx_event_bus_kafka/internal/tests/test_consumer.py
@@ -495,6 +495,54 @@ class TestEmitSignals(TestCase):
             "KafkaError{code=ERR_123?,val=123,str=\"done broke\"}",
         )
 
+    @patch('edx_event_bus_kafka.internal.consumer.set_custom_attribute', autospec=True)
+    @patch('edx_event_bus_kafka.internal.consumer.logger', autospec=True)
+    @override_settings(
+        EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL='http://localhost:12345',
+        EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321',
+        EVENT_BUS_TOPIC_PREFIX='local',
+    )
+    def test_control_message_in_consume_loop(self, mock_logger, mock_set_custom_attribute):
+        """
+        Test that Kafka control/error messages are handled gracefully in the consume loop.
+        
+        Control messages have msg.error() set and should be logged as warnings and skipped,
+        not processed as CloudEvent messages.
+        """
+        control_msg = FakeMessage(
+            partition=0,
+            offset=None,
+            error=KafkaError(-191, reason="Application maximum poll interval (10000ms) exceeded by 347ms"),
+            value=b'Application maximum poll interval (10000ms) exceeded by 347ms',
+            key=None,
+            headers=None,
+        )
+        
+        poll_call_count = [0]
+        
+        def poll_side_effect(*args, **kwargs):
+            poll_call_count[0] += 1
+            if poll_call_count[0] == 1:
+                return control_msg
+            else:
+                self.event_consumer._shut_down()  # pylint: disable=protected-access
+                return None
+
+        mock_consumer = Mock(**{'poll.side_effect': poll_side_effect}, autospec=True)
+        self.event_consumer.consumer = mock_consumer
+        
+        self.event_consumer.consume_indefinitely()
+        
+        mock_logger.warning.assert_called_once()
+        warning_call_args = mock_logger.warning.call_args.args[0]
+        assert "Received Kafka control/error message" in warning_call_args
+        assert "-191" in warning_call_args
+        assert "maximum poll interval" in warning_call_args.lower()
+        
+        mock_consumer.commit.assert_not_called()
+        
+        mock_logger.exception.assert_not_called()
+
     @override_settings(
         EVENT_BUS_TOPIC_PREFIX='local',
     )


### PR DESCRIPTION
**Description**

- Add 14 diagnostic fields to run_context (service, environment, pod_name, etc.)
- Include runtime statistics (messages_processed, messages_failed, uptime_seconds)
- Improve error messages for debugging poll timeout issues in production
- Add operational context for better Datadog/Splunk analysis"

**Private JIRA link:**
https://2u-internal.atlassian.net/browse/BOMS-444

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] Noted any: Concerns, dependencies, deadlines, tickets, testing instructions
